### PR TITLE
Implement company editing FSM

### DIFF
--- a/dialogs/edit_company.py
+++ b/dialogs/edit_company.py
@@ -1,0 +1,91 @@
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import (
+    ConversationHandler, MessageHandler, CallbackQueryHandler,
+    CommandHandler, filters, ContextTypes
+)
+from db import get_company, update_company
+
+EDIT_SELECT, EDIT_VALUE = range(2)
+
+FIELDS = [
+    ("opf", "ОПФ"),
+    ("name", "Базова назва"),
+    ("full_name", "Повна назва"),
+    ("short_name", "Скорочена назва"),
+    ("edrpou", "ЄДРПОУ"),
+    ("bank_account", "р/р (IBAN)"),
+    ("tax_group", "Група оподаткування"),
+    ("is_vat_payer", "Платник ПДВ (Так/Ні)"),
+    ("vat_ipn", "ІПН платника ПДВ"),
+    ("address_legal", "Юридична адреса"),
+    ("address_postal", "Поштова адреса"),
+    ("director", "ПІБ директора"),
+]
+
+def _field_name(key: str) -> str:
+    return dict(FIELDS)[key]
+
+async def edit_company_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    company_id = int(query.data.split(":")[1])
+    context.user_data["edit_company_id"] = company_id
+    keyboard = [
+        [InlineKeyboardButton(name, callback_data=f"edit_company_fsm:{company_id}:{key}")]
+        for key, name in FIELDS
+    ]
+    keyboard.append([InlineKeyboardButton("Назад", callback_data=f"company_card:{company_id}")])
+    await query.message.edit_text(
+        "Оберіть поле для редагування:",
+        reply_markup=InlineKeyboardMarkup(keyboard)
+    )
+    return EDIT_SELECT
+
+async def edit_company_input(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    _, company_id, field_key = query.data.split(":")
+    company_id = int(company_id)
+    context.user_data["edit_company_id"] = company_id
+    context.user_data["edit_company_field"] = field_key
+    company = await get_company(company_id)
+    old_value = company[field_key]
+    if field_key == "is_vat_payer":
+        display_old = "Так" if old_value else "Ні"
+    else:
+        display_old = old_value if old_value is not None else "(порожньо)"
+    await query.message.edit_text(
+        f"Поточне значення: <b>{display_old}</b>\n"
+        f"Введіть нове значення для: {_field_name(field_key)}",
+        parse_mode="HTML"
+    )
+    return EDIT_VALUE
+
+async def edit_company_save(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    value = update.message.text.strip()
+    company_id = context.user_data.get("edit_company_id")
+    field_key = context.user_data.get("edit_company_field")
+    if field_key == "is_vat_payer":
+        val = value.lower()
+        if val in ("так", "1", "true", "yes"):
+            value = True
+        elif val in ("ні", "0", "false", "no"):
+            value = False
+        else:
+            await update.message.reply_text('Введіть "Так" або "Ні"')
+            return EDIT_VALUE
+    await update_company(company_id, {field_key: value})
+    await update.message.reply_text("✅ Зміни збережено!")
+    return ConversationHandler.END
+
+edit_company_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(edit_company_menu, pattern=r"^company_edit:\d+$")],
+    states={
+        EDIT_SELECT: [
+            CallbackQueryHandler(edit_company_input, pattern=r"^edit_company_fsm:\d+:\w+$"),
+            CallbackQueryHandler(edit_company_menu, pattern=r"^company_edit:\d+$"),
+        ],
+        EDIT_VALUE: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, edit_company_save),
+        ],
+    },
+    fallbacks=[CommandHandler("start", lambda u, c: None)],
+)

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -155,11 +155,22 @@ async def admin_delete_handler(update, context):
         await update.callback_query.edit_message_text("Видалення об’єктів — в розробці.", reply_markup=InlineKeyboardMarkup([]))
 
 async def admin_tov_edit_handler(update, context):
+    companies = await get_companies()
+    text = "<b>Оберіть ТОВ для редагування:</b>"
+    if not companies:
+        text = "Немає жодного ТОВ-орендаря."
+    keyboard = [
+        [InlineKeyboardButton(
+            f"{c['short_name'] or c['full_name']}", callback_data=f"company_edit:{c['id']}"
+        )]
+        for c in companies
+    ] if companies else []
+    inline_kb = InlineKeyboardMarkup(keyboard)
     msg = getattr(update, 'message', None)
     if msg:
-        await msg.reply_text("Редагування ТОВ — в розробці.")
+        await msg.reply_text(text, reply_markup=inline_kb, parse_mode="HTML")
     else:
-        await update.callback_query.edit_message_text("Редагування ТОВ — в розробці.", reply_markup=InlineKeyboardMarkup([]))
+        await update.callback_query.edit_message_text(text, reply_markup=inline_kb, parse_mode="HTML")
 
 async def admin_tov_delete_handler(update, context):
     msg = getattr(update, 'message', None)

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from dialogs.add_docs_fsm import add_docs_conv, send_pdf, delete_pdf  # тіль
 from db import database
 
 from dialogs.admin_tov import admin_tov_add_conv
+from dialogs.edit_company import edit_company_conv
 
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 WEBHOOK_PATH = "/webhook"
@@ -85,6 +86,7 @@ application.add_handler(CallbackQueryHandler(to_lands_list, pattern=r"^to_lands_
 application.add_handler(edit_field_conv)
 application.add_handler(edit_land_conv)
 application.add_handler(edit_land_owner_conv)
+application.add_handler(edit_company_conv)
 
 # --- PDF через FTP ---
 application.add_handler(add_docs_conv)
@@ -115,7 +117,6 @@ application.add_handler(MessageHandler(filters.Regex("^↩️ Адмінпане
 application.add_handler(CallbackQueryHandler(admin_company_card_callback, pattern=r"^company_card:\d+$"))
 application.add_handler(CallbackQueryHandler(admin_tov_list_handler, pattern=r"^company_list$"))
 application.add_handler(CallbackQueryHandler(admin_panel_handler, pattern=r"^admin_panel$"))
-application.add_handler(CallbackQueryHandler(admin_tov_edit_handler, pattern=r"^company_edit:\d+$"))
 application.add_handler(admin_tov_add_conv)
 
 


### PR DESCRIPTION
## Summary
- add a new FSM `edit_company_conv` to edit a company's fields
- show company list for editing in `admin_tov_edit_handler`
- register the new conversation in the bot setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886080fa4c08321b90bde5bebc4a3ce