### PR TITLE
Add startup admin creation

### DIFF
--- a/db.py
+++ b/db.py
@@ -162,5 +162,19 @@ async def log_admin_action(admin_id: int, action: str):
     )
     await database.execute(query)
 
+async def ensure_admin(tg_id: int, username: str | None = None):
+    """Ensure a user exists with admin role and is active."""
+    user = await get_user_by_tg_id(tg_id)
+    if not user:
+        await add_user(tg_id, username=username, role="admin")
+        return
+    update_data = {}
+    if user["role"] != "admin":
+        update_data["role"] = "admin"
+    if not user["is_active"]:
+        update_data["is_active"] = True
+    if update_data:
+        await update_user(tg_id, update_data)
+
 # Create all tables if they do not exist.
 metadata.create_all(engine)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from dialogs.edit_field import edit_field_conv
 from dialogs.edit_land import edit_land_conv
 from dialogs.edit_land_owner import edit_land_owner_conv
 from dialogs.add_docs_fsm import add_docs_conv, send_pdf, delete_pdf  # тільки FTP!
-from db import database
+from db import database, ensure_admin
 
 from dialogs.admin_tov import admin_tov_add_conv
 from dialogs.edit_company import edit_company_conv
@@ -38,12 +38,15 @@ WEBHOOK_URL = os.getenv("WEBHOOK_URL")
 
 app = FastAPI()
 application = Application.builder().token(TOKEN).build()
+DEFAULT_ADMIN_IDS = [int(i) for i in os.getenv("ADMIN_IDS", "370806943").split(",") if i]
 is_initialized = False
 
 @app.on_event("startup")
 async def on_startup():
     global is_initialized
     await database.connect()
+    for admin_id in DEFAULT_ADMIN_IDS:
+        await ensure_admin(admin_id)
     if not is_initialized:
         await application.initialize()
         await application.bot.set_webhook(WEBHOOK_URL)


### PR DESCRIPTION
## Summary
- ensure admin users exist in db
- read admin IDs from `ADMIN_IDS` env var and ensure them on startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688619c871048321917f374781de6e19