### PR TITLE
User management menu

### DIFF
--- a/db.py
+++ b/db.py
@@ -112,6 +112,7 @@ User = sqlalchemy.Table(
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("telegram_id", sqlalchemy.BigInteger, unique=True),
     sqlalchemy.Column("username", sqlalchemy.String(255)),
+    sqlalchemy.Column("full_name", sqlalchemy.String(255), nullable=True),
     sqlalchemy.Column("role", sqlalchemy.String(10), default="user"),
     sqlalchemy.Column("is_active", sqlalchemy.Boolean, default=True),
     sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
@@ -127,10 +128,16 @@ AdminAction = sqlalchemy.Table(
     sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
 )
 
-async def add_user(tg_id: int, username: str | None = None, role: str = "user"):
+async def add_user(
+    tg_id: int,
+    username: str | None = None,
+    role: str = "user",
+    full_name: str | None = None,
+):
     query = User.insert().values(
         telegram_id=tg_id,
         username=username,
+        full_name=full_name,
         role=role,
         is_active=True,
         created_at=datetime.utcnow(),

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,5 +1,11 @@
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
-from telegram.ext import ContextTypes
+from telegram.ext import (
+    ContextTypes,
+    ConversationHandler,
+    CallbackQueryHandler,
+    MessageHandler,
+    filters,
+)
 from keyboards.menu import (
     main_menu, main_menu_admin,
     payers_menu, lands_menu, fields_menu, contracts_menu,
@@ -9,6 +15,17 @@ from db import (
     get_companies, get_company,
     get_user_by_tg_id, add_user, get_users, update_user, log_admin_action
 )
+
+# --- States for user management conversations ---
+(
+    ADD_USER_ID,
+    ADD_USER_NAME,
+    CHANGE_ROLE_ID,
+    CHANGE_ROLE_ROLE,
+    BLOCK_USER_ID,
+    CHANGE_NAME_ID,
+    CHANGE_NAME_VALUE,
+) = range(7)
 
 
 def admin_only(handler):
@@ -163,11 +180,195 @@ async def admin_templates_handler(update, context):
 
 @admin_only
 async def admin_users_handler(update, context):
+    keyboard = [
+        [InlineKeyboardButton("\U0001F4C4 Список користувачів", callback_data="user_list")],
+        [InlineKeyboardButton("\u2795 Додати користувача", callback_data="user_add")],
+        [InlineKeyboardButton("\U0001F501 Змінити роль", callback_data="user_role")],
+        [InlineKeyboardButton("✏️ Змінити ПІБ", callback_data="user_fullname")],
+        [InlineKeyboardButton("\U0001F6AB Блокування", callback_data="user_block")],
+        [InlineKeyboardButton("↩️ Адмінпанель", callback_data="admin_panel")]
+    ]
     msg = getattr(update, 'message', None)
     if msg:
-        await msg.reply_text("Менеджмент користувачів — в розробці.")
+        await msg.reply_text(
+            "Менеджмент користувачів:",
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
     else:
-        await update.callback_query.edit_message_text("Менеджмент користувачів — в розробці.", reply_markup=InlineKeyboardMarkup([]))
+        await update.callback_query.edit_message_text(
+            "Менеджмент користувачів:",
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
+
+@admin_only
+async def admin_user_list(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    users = await get_users()
+    lines = [
+        f"{u['full_name'] or '—'} / <code>{u['telegram_id']}</code> | {u['role']} | "
+        f"{'активний' if u['is_active'] else 'заблокований'}" for u in users
+    ]
+    text = '<b>Список користувачів</b>:\n' + ("\n".join(lines) if lines else "Користувачів не знайдено.")
+    keyboard = [[InlineKeyboardButton("↩️ Назад", callback_data="admin_users")]]
+    await query.message.edit_text(text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML")
+
+
+@admin_only
+async def add_user_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.message.edit_text(
+        "Введіть Telegram ID користувача:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ Скасувати", callback_data="admin_users")]])
+    )
+    return ADD_USER_ID
+
+
+@admin_only
+async def add_user_get_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("Введіть числовий ID:")
+        return ADD_USER_ID
+    user = await get_user_by_tg_id(tg_id)
+    if user:
+        await update.message.reply_text("Користувач вже існує.")
+        return ADD_USER_ID
+    context.user_data["new_user_id"] = tg_id
+    await update.message.reply_text("Введіть ПІБ користувача:")
+    return ADD_USER_NAME
+
+
+@admin_only
+async def add_user_finish(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    tg_id = context.user_data.get("new_user_id")
+    full_name = update.message.text.strip()
+    await add_user(tg_id, full_name=full_name)
+    await log_admin_action(update.effective_user.id, f"add_user {tg_id}")
+    await update.message.reply_text("Користувача додано.")
+    await update.message.reply_text(
+        "Менеджмент користувачів:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("↩️ Назад", callback_data="admin_users")]])
+    )
+    return ConversationHandler.END
+
+
+@admin_only
+async def change_role_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.message.edit_text(
+        "Введіть Telegram ID користувача:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ Скасувати", callback_data="admin_users")]])
+    )
+    return CHANGE_ROLE_ID
+
+
+@admin_only
+async def change_role_get_role(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("Введіть числовий ID:")
+        return CHANGE_ROLE_ID
+    user = await get_user_by_tg_id(tg_id)
+    if not user:
+        await update.message.reply_text("Користувача не знайдено.")
+        return CHANGE_ROLE_ID
+    context.user_data["change_role_id"] = tg_id
+    await update.message.reply_text("Введіть нову роль (user/admin):")
+    return CHANGE_ROLE_ROLE
+
+
+@admin_only
+async def change_role_finish(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    tg_id = context.user_data.get("change_role_id")
+    role = update.message.text.strip().lower()
+    if role not in {"user", "admin"}:
+        await update.message.reply_text("Некоректна роль. Введіть user або admin:")
+        return CHANGE_ROLE_ROLE
+    await update_user(tg_id, {"role": role})
+    await log_admin_action(update.effective_user.id, f"change_role {tg_id} {role}")
+    await update.message.reply_text(f"Роль змінено на {role}.")
+    await update.message.reply_text(
+        "Менеджмент користувачів:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("↩️ Назад", callback_data="admin_users")]])
+    )
+    return ConversationHandler.END
+
+
+@admin_only
+async def change_name_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.message.edit_text(
+        "Введіть Telegram ID користувача:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ Скасувати", callback_data="admin_users")]])
+    )
+    return CHANGE_NAME_ID
+
+
+@admin_only
+async def change_name_get_full(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("Введіть числовий ID:")
+        return CHANGE_NAME_ID
+    user = await get_user_by_tg_id(tg_id)
+    if not user:
+        await update.message.reply_text("Користувача не знайдено.")
+        return CHANGE_NAME_ID
+    context.user_data["change_name_id"] = tg_id
+    await update.message.reply_text("Введіть новий ПІБ:")
+    return CHANGE_NAME_VALUE
+
+
+@admin_only
+async def change_name_finish(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    tg_id = context.user_data.get("change_name_id")
+    full_name = update.message.text.strip()
+    await update_user(tg_id, {"full_name": full_name})
+    await log_admin_action(update.effective_user.id, f"change_full_name {tg_id}")
+    await update.message.reply_text("✅ ПІБ оновлено")
+    await update.message.reply_text(
+        "Менеджмент користувачів:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("↩️ Назад", callback_data="admin_users")]])
+    )
+    return ConversationHandler.END
+
+
+@admin_only
+async def block_user_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.message.edit_text(
+        "Введіть Telegram ID користувача:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("❌ Скасувати", callback_data="admin_users")]])
+    )
+    return BLOCK_USER_ID
+
+
+@admin_only
+async def block_user_finish(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    try:
+        tg_id = int(update.message.text.strip())
+    except ValueError:
+        await update.message.reply_text("Введіть числовий ID:")
+        return BLOCK_USER_ID
+    user = await get_user_by_tg_id(tg_id)
+    if not user:
+        await update.message.reply_text("Користувача не знайдено.")
+    else:
+        new_status = not user["is_active"]
+        await update_user(tg_id, {"is_active": new_status})
+        action = "unblock" if new_status else "block"
+        await log_admin_action(update.effective_user.id, f"{action} {tg_id}")
+        text = "Користувача розблоковано." if new_status else "Користувача заблоковано."
+        await update.message.reply_text(text)
+    await update.message.reply_text(
+        "Менеджмент користувачів:",
+        reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("↩️ Назад", callback_data="admin_users")]])
+    )
+    return ConversationHandler.END
+
 
 @admin_only
 async def admin_delete_handler(update, context):
@@ -276,3 +477,40 @@ async def cmd_unblock(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update_user(tg_id, {'is_active': True})
     await log_admin_action(update.effective_user.id, f"unblock {tg_id}")
     await update.message.reply_text('Користувача розблоковано.')
+
+
+# --- Conversation handlers for user management ---
+add_user_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(add_user_start, pattern=r"^user_add$")],
+    states={
+        ADD_USER_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_user_get_name)],
+        ADD_USER_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_user_finish)],
+    },
+    fallbacks=[CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$")]
+)
+
+change_role_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(change_role_start, pattern=r"^user_role$")],
+    states={
+        CHANGE_ROLE_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, change_role_get_role)],
+        CHANGE_ROLE_ROLE: [MessageHandler(filters.TEXT & ~filters.COMMAND, change_role_finish)],
+    },
+    fallbacks=[CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$")]
+)
+
+block_user_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(block_user_start, pattern=r"^user_block$")],
+    states={
+        BLOCK_USER_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, block_user_finish)],
+    },
+    fallbacks=[CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$")]
+)
+
+change_name_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(change_name_start, pattern=r"^user_fullname$")],
+    states={
+        CHANGE_NAME_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, change_name_get_full)],
+        CHANGE_NAME_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, change_name_finish)],
+    },
+    fallbacks=[CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$")]
+)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ from handlers.menu import (
     contracts_menu_handler, payments_menu_handler, reports_menu_handler, search_menu_handler,
     admin_panel_handler, admin_tov_handler, admin_templates_handler,
     admin_users_handler, admin_delete_handler, admin_tov_list_handler,
-    admin_tov_edit_handler, admin_tov_delete_handler, to_admin_panel, admin_company_card_callback
+    admin_tov_edit_handler, admin_tov_delete_handler, to_admin_panel, admin_company_card_callback,
+    admin_user_list, add_user_conv, change_role_conv, block_user_conv, change_name_conv
 )
 from handlers.menu import (
     cmd_list_users, cmd_add_user, cmd_promote, cmd_demote, cmd_block, cmd_unblock
@@ -120,6 +121,12 @@ application.add_handler(MessageHandler(filters.Regex("^📄 Шаблони до�
 application.add_handler(MessageHandler(filters.Regex("^👥 Користувачі$"), admin_users_handler))
 application.add_handler(MessageHandler(filters.Regex("^🗑️ Видалення об’єктів$"), admin_delete_handler))
 application.add_handler(MessageHandler(filters.Regex("^↩️ Головне меню$"), to_main_menu))
+application.add_handler(CallbackQueryHandler(admin_user_list, pattern=r"^user_list$"))
+application.add_handler(add_user_conv)
+application.add_handler(change_role_conv)
+application.add_handler(block_user_conv)
+application.add_handler(change_name_conv)
+application.add_handler(CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$"))
 # --- АДМІНКА ТОВ ---
 application.add_handler(MessageHandler(filters.Regex("^🏢 ТОВ-орендарі$"), admin_tov_handler))
 application.add_handler(MessageHandler(filters.Regex("^📋 Список ТОВ$"), admin_tov_list_handler))

--- a/migrations/001_add_full_name.py
+++ b/migrations/001_add_full_name.py
@@ -1,0 +1,16 @@
+import os
+import asyncio
+from databases import Database
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+async def main():
+    db = Database(DATABASE_URL)
+    await db.connect()
+    await db.execute(
+        'ALTER TABLE "user" ADD COLUMN IF NOT EXISTS full_name VARCHAR(255);'
+    )
+    await db.disconnect()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- activate user management menu for admins
- allow listing and modifying user accounts
- add full name support and improve management FSMs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68861d5318f08321b3d6c8f1fee0bd4b