### PR TITLE
Update start handler to store full user names

### DIFF
--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -38,7 +38,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     username = update.effective_user.username
     user = await get_user_by_tg_id(tg_id)
     if not user:
-        await add_user(tg_id, username=username)
+        await add_user(
+            tg_id,
+            username=username,
+            full_name=update.effective_user.full_name,
+        )
         user_role = "user"
     else:
         user_role = user["role"]


### PR DESCRIPTION
## Summary
- pass `update.effective_user.full_name` to `add_user` when a new user runs `/start`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68862906d7d483219cc0440950181d0f