### PR TITLE
Fix user management menu

### DIFF
--- a/db.py
+++ b/db.py
@@ -111,6 +111,7 @@ User = sqlalchemy.Table(
     metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("telegram_id", sqlalchemy.BigInteger, unique=True),
+    sqlalchemy.Column("full_name", sqlalchemy.String(255)),
     sqlalchemy.Column("username", sqlalchemy.String(255)),
     sqlalchemy.Column("role", sqlalchemy.String(10), default="user"),
     sqlalchemy.Column("is_active", sqlalchemy.Boolean, default=True),
@@ -127,10 +128,16 @@ AdminAction = sqlalchemy.Table(
     sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
 )
 
-async def add_user(tg_id: int, username: str | None = None, role: str = "user"):
+async def add_user(
+    tg_id: int,
+    username: str | None = None,
+    role: str = "user",
+    full_name: str | None = None,
+):
     query = User.insert().values(
         telegram_id=tg_id,
         username=username,
+        full_name=full_name,
         role=role,
         is_active=True,
         created_at=datetime.utcnow(),

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from handlers.menu import (
     admin_panel_handler, admin_tov_handler, admin_templates_handler,
     admin_users_handler, admin_delete_handler, admin_tov_list_handler,
     admin_tov_edit_handler, admin_tov_delete_handler, to_admin_panel, admin_company_card_callback,
-    admin_user_list, add_user_conv, change_role_conv, block_user_conv
+    admin_user_list, add_user_conv, change_role_conv, block_user_conv, change_name_conv
 )
 from handlers.menu import (
     cmd_list_users, cmd_add_user, cmd_promote, cmd_demote, cmd_block, cmd_unblock
@@ -125,6 +125,7 @@ application.add_handler(CallbackQueryHandler(admin_user_list, pattern=r"^user_li
 application.add_handler(add_user_conv)
 application.add_handler(change_role_conv)
 application.add_handler(block_user_conv)
+application.add_handler(change_name_conv)
 application.add_handler(CallbackQueryHandler(admin_users_handler, pattern=r"^admin_users$"))
 # --- АДМІНКА ТОВ ---
 application.add_handler(MessageHandler(filters.Regex("^🏢 ТОВ-орендарі$"), admin_tov_handler))


### PR DESCRIPTION
## Summary
- support `full_name` in user table and add_user function
- show full names in admin user list
- expand admin user management: add/change role/change full name flows
- wire in new conversation handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68862af4c09883218a8348cb34d36362