### PR TITLE
Implement agreement templates management

### DIFF
--- a/db.py
+++ b/db.py
@@ -128,6 +128,18 @@ AdminAction = sqlalchemy.Table(
     sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
 )
 
+# === Шаблони договорів ===
+AgreementTemplate = sqlalchemy.Table(
+    "agreement_template",
+    metadata,
+    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("name", sqlalchemy.String(255)),
+    sqlalchemy.Column("type", sqlalchemy.String(32)),
+    sqlalchemy.Column("file_path", sqlalchemy.String(255)),
+    sqlalchemy.Column("is_active", sqlalchemy.Boolean, default=True),
+    sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
+)
+
 async def add_user(
     tg_id: int,
     username: str | None = None,
@@ -167,6 +179,30 @@ async def log_admin_action(admin_id: int, action: str):
         action=action,
         created_at=datetime.utcnow(),
     )
+    await database.execute(query)
+
+# === Agreement Template helpers ===
+async def add_agreement_template(data: dict):
+    query = AgreementTemplate.insert().values(**data)
+    return await database.execute(query)
+
+async def get_agreement_templates(active_only: bool | None = None):
+    query = AgreementTemplate.select()
+    if active_only is not None:
+        query = query.where(AgreementTemplate.c.is_active == active_only)
+    query = query.order_by(AgreementTemplate.c.id)
+    return await database.fetch_all(query)
+
+async def get_agreement_template(template_id: int):
+    query = AgreementTemplate.select().where(AgreementTemplate.c.id == template_id)
+    return await database.fetch_one(query)
+
+async def update_agreement_template(template_id: int, data: dict):
+    query = AgreementTemplate.update().where(AgreementTemplate.c.id == template_id).values(**data)
+    await database.execute(query)
+
+async def delete_agreement_template(template_id: int):
+    query = AgreementTemplate.delete().where(AgreementTemplate.c.id == template_id)
     await database.execute(query)
 
 async def ensure_admin(tg_id: int, username: str | None = None):

--- a/dialogs/agreement_template.py
+++ b/dialogs/agreement_template.py
@@ -1,0 +1,227 @@
+from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
+from telegram.ext import (
+    ContextTypes, ConversationHandler, MessageHandler,
+    CallbackQueryHandler, filters
+)
+from datetime import datetime
+import os
+
+from db import (
+    add_agreement_template, get_agreement_templates, get_agreement_template,
+    update_agreement_template, delete_agreement_template
+)
+from ftp_utils import upload_file_ftp, delete_file_ftp
+
+TEMPLATE_TYPES = {
+    "rent": "Оренда",
+    "emphyteusis": "Емфітевзис",
+    "additional": "Додаткова угода",
+}
+
+ALLOWED_VARS = [
+    "{{payer_full_name}} — ПІБ пайовика",
+    "{{payer_passport}} — паспортні дані",
+    "{{payer_address}} — адреса проживання",
+    "{{agreement_number}} — номер договору",
+    "{{agreement_date}} — дата підписання",
+    "{{agreement_start}} — дата початку дії",
+    "{{agreement_end}} — дата завершення дії",
+    "{{land_list}} — список ділянок (рядком)",
+    "{{total_area}} — сумарна площа, га",
+    "{{company_name}} — назва ТОВ",
+    "{{company_director}} — директор ТОВ",
+]
+
+ADD_TYPE, ADD_NAME, ADD_FILE, REPLACE_FILE = range(4)
+
+async def show_templates(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    msg = update.message if update.message else update.callback_query.message
+    templates = await get_agreement_templates()
+    text = "<b>Шаблони договорів</b>:\n"
+    if not templates:
+        text += "Немає жодного шаблону."
+    keyboard = []
+    for t in templates:
+        status = "✅" if t["is_active"] else "❌"
+        t_type = TEMPLATE_TYPES.get(t["type"], t["type"])
+        keyboard.append([
+            InlineKeyboardButton(
+                f"{status} {t['name']} ({t_type})",
+                callback_data=f"template_card:{t['id']}"
+            )
+        ])
+    keyboard.append([InlineKeyboardButton("➕ Додати шаблон", callback_data="template_add")])
+    keyboard.append([InlineKeyboardButton("↩️ Адмінпанель", callback_data="admin_panel")])
+    if update.callback_query:
+        await update.callback_query.edit_message_text(
+            text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML"
+        )
+    else:
+        await msg.reply_text(text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML")
+
+async def show_templates_cb(update, context):
+    await show_templates(update, context)
+
+async def template_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    template_id = int(query.data.split(":")[1])
+    tmpl = await get_agreement_template(template_id)
+    if not tmpl:
+        await query.answer("Шаблон не знайдено!", show_alert=True)
+        return
+    status = "Так" if tmpl["is_active"] else "Ні"
+    t_type = TEMPLATE_TYPES.get(tmpl["type"], tmpl["type"])
+    text = (
+        f"<b>{tmpl['name']}</b>\n"
+        f"Тип: <code>{t_type}</code>\n"
+        f"Активний: <code>{status}</code>"
+    )
+    kb = [
+        [InlineKeyboardButton("♻️ Оновити файл", callback_data=f"template_replace:{template_id}")],
+        [InlineKeyboardButton(
+            "✅ Увімкнути" if not tmpl["is_active"] else "🚫 Вимкнути",
+            callback_data=f"template_toggle:{template_id}"
+        )],
+        [InlineKeyboardButton("🗑 Видалити", callback_data=f"template_delete:{template_id}")],
+        [InlineKeyboardButton("↩️ До списку", callback_data="template_list")]
+    ]
+    await query.edit_message_text(text, reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
+
+async def template_toggle(update, context):
+    query = update.callback_query
+    template_id = int(query.data.split(":")[1])
+    tmpl = await get_agreement_template(template_id)
+    if not tmpl:
+        await query.answer("Шаблон не знайдено!", show_alert=True)
+        return
+    new_status = not tmpl["is_active"]
+    await update_agreement_template(template_id, {"is_active": new_status})
+    await template_card(update, context)
+
+async def template_delete(update, context):
+    query = update.callback_query
+    template_id = int(query.data.split(":")[1])
+    tmpl = await get_agreement_template(template_id)
+    if not tmpl:
+        await query.answer("Шаблон не знайдено!", show_alert=True)
+        return
+    if tmpl["file_path"]:
+        try:
+            delete_file_ftp(tmpl["file_path"])
+        except Exception:
+            pass
+    await delete_agreement_template(template_id)
+    await query.answer("Шаблон видалено!")
+    await show_templates_cb(update, context)
+
+async def add_template_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    keyboard = [[InlineKeyboardButton(name, callback_data=f"tmpl_type:{key}")] for key, name in TEMPLATE_TYPES.items()]
+    keyboard.append([InlineKeyboardButton("↩️ Назад", callback_data="template_list")])
+    await query.edit_message_text(
+        "Оберіть тип шаблону:",
+        reply_markup=InlineKeyboardMarkup(keyboard)
+    )
+    return ADD_TYPE
+
+async def add_template_type(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    tmpl_type = query.data.split(":")[1]
+    context.user_data["tmpl_type"] = tmpl_type
+    await query.message.edit_text("Введіть назву шаблону:")
+    return ADD_NAME
+
+async def add_template_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    context.user_data["tmpl_name"] = update.message.text.strip()
+    vars_text = "\n".join(ALLOWED_VARS)
+    await update.message.reply_text(
+        "Надішліть файл .docx (до 2MB).\nДопустимі змінні:\n" + vars_text
+    )
+    return ADD_FILE
+
+async def add_template_file(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    doc = update.message.document
+    if not doc or not doc.file_name.lower().endswith(".docx"):
+        await update.message.reply_text("Надішліть файл у форматі .docx")
+        return ADD_FILE
+    if doc.file_size and doc.file_size > 2 * 1024 * 1024:
+        await update.message.reply_text("Файл перевищує 2MB. Надішліть менший файл")
+        return ADD_FILE
+    tmpl_data = {
+        "name": context.user_data["tmpl_name"],
+        "type": context.user_data["tmpl_type"],
+        "file_path": "",
+        "created_at": datetime.utcnow(),
+    }
+    template_id = await add_agreement_template(tmpl_data)
+    remote_path = f"templates/agreements/{template_id}.docx"
+    tmp_dir = "temp_docs"
+    os.makedirs(tmp_dir, exist_ok=True)
+    local_path = os.path.join(tmp_dir, f"{template_id}.docx")
+    await doc.get_file().download_to_drive(local_path)
+    upload_file_ftp(local_path, remote_path)
+    os.remove(local_path)
+    await update_agreement_template(template_id, {"file_path": remote_path})
+    await update.message.reply_text("✅ Шаблон збережено")
+    context.user_data.pop("tmpl_name", None)
+    context.user_data.pop("tmpl_type", None)
+    await show_templates(update, context)
+    return ConversationHandler.END
+
+async def replace_template_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    template_id = int(query.data.split(":")[1])
+    context.user_data["replace_template_id"] = template_id
+    await query.message.reply_text("Надішліть новий файл .docx (до 2MB):")
+    return REPLACE_FILE
+
+async def replace_template_file(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    doc = update.message.document
+    if not doc or not doc.file_name.lower().endswith(".docx"):
+        await update.message.reply_text("Надішліть файл у форматі .docx")
+        return REPLACE_FILE
+    if doc.file_size and doc.file_size > 2 * 1024 * 1024:
+        await update.message.reply_text("Файл перевищує 2MB. Надішліть менший файл")
+        return REPLACE_FILE
+    template_id = context.user_data.pop("replace_template_id", None)
+    if not template_id:
+        await update.message.reply_text("Сталася помилка.")
+        return ConversationHandler.END
+    remote_path = f"templates/agreements/{template_id}.docx"
+    tmp_dir = "temp_docs"
+    os.makedirs(tmp_dir, exist_ok=True)
+    local_path = os.path.join(tmp_dir, f"{template_id}.docx")
+    await doc.get_file().download_to_drive(local_path)
+    upload_file_ftp(local_path, remote_path)
+    os.remove(local_path)
+    await update_agreement_template(template_id, {"file_path": remote_path})
+    await update.message.reply_text("✅ Файл оновлено")
+    await show_templates(update, context)
+    return ConversationHandler.END
+
+add_template_conv = ConversationHandler(
+    entry_points=[
+        CallbackQueryHandler(add_template_start, pattern=r"^template_add$"),
+        MessageHandler(filters.Regex("^➕ Додати шаблон$"), add_template_start)
+    ],
+    states={
+        ADD_TYPE: [CallbackQueryHandler(add_template_type, pattern=r"^tmpl_type:\w+$")],
+        ADD_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_template_name)],
+        ADD_FILE: [MessageHandler(filters.Document.ALL, add_template_file)],
+    },
+    fallbacks=[CallbackQueryHandler(show_templates_cb, pattern=r"^template_list$")]
+)
+
+replace_template_conv = ConversationHandler(
+    entry_points=[CallbackQueryHandler(replace_template_start, pattern=r"^template_replace:\d+$")],
+    states={
+        REPLACE_FILE: [MessageHandler(filters.Document.ALL, replace_template_file)],
+    },
+    fallbacks=[CallbackQueryHandler(template_card, pattern=r"^template_card:\d+$")]
+)
+
+# Callback handlers for list and item actions
+template_card_cb = CallbackQueryHandler(template_card, pattern=r"^template_card:\d+$")
+template_toggle_cb = CallbackQueryHandler(template_toggle, pattern=r"^template_toggle:\d+$")
+template_delete_cb = CallbackQueryHandler(template_delete, pattern=r"^template_delete:\d+$")
+template_list_cb = CallbackQueryHandler(show_templates_cb, pattern=r"^template_list$")

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -10,7 +10,8 @@ from telegram.ext import (
 from keyboards.menu import (
     main_menu, main_menu_admin,
     payers_menu, lands_menu, fields_menu, contracts_menu,
-    payments_menu, reports_menu, search_menu, admin_panel_menu, admin_tov_menu
+    payments_menu, reports_menu, search_menu, admin_panel_menu, admin_tov_menu,
+    admin_templates_menu
 )
 from db import (
     get_companies,
@@ -20,6 +21,10 @@ from db import (
     get_users,
     update_user,
     log_admin_action,
+)
+from dialogs.agreement_template import (
+    show_templates_cb, add_template_conv, replace_template_conv,
+    template_card_cb, template_toggle_cb, template_delete_cb, template_list_cb
 )
 
 (
@@ -179,9 +184,9 @@ async def admin_company_card_callback(update, context):
 async def admin_templates_handler(update, context):
     msg = getattr(update, 'message', None)
     if msg:
-        await msg.reply_text("Менеджмент шаблонів договорів — в розробці.")
+        await msg.reply_text("Менеджмент шаблонів договорів:", reply_markup=admin_templates_menu)
     else:
-        await update.callback_query.edit_message_text("Менеджмент шаблонів договорів — в розробці.", reply_markup=InlineKeyboardMarkup([]))
+        await show_templates_cb(update, context)
 
 @admin_only
 async def admin_users_handler(update, context):

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -113,3 +113,12 @@ admin_tov_menu = ReplyKeyboardMarkup(
     ],
     resize_keyboard=True
 )
+
+# --- Меню шаблонів договорів ---
+admin_templates_menu = ReplyKeyboardMarkup(
+    [
+        ["➕ Додати шаблон", "📋 Список шаблонів"],
+        ["↩️ Адмінпанель"]
+    ],
+    resize_keyboard=True
+)

--- a/main.py
+++ b/main.py
@@ -32,6 +32,10 @@ from db import database, ensure_admin
 
 from dialogs.admin_tov import admin_tov_add_conv
 from dialogs.edit_company import edit_company_conv
+from dialogs.agreement_template import (
+    add_template_conv, replace_template_conv,
+    template_card_cb, template_toggle_cb, template_delete_cb, template_list_cb
+)
 
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 WEBHOOK_PATH = "/webhook"
@@ -117,7 +121,14 @@ application.add_handler(MessageHandler(filters.COMMAND, to_main_menu))
 
 # --- АДМІНКА ---
 application.add_handler(admin_tov_add_conv)
+application.add_handler(add_template_conv)
+application.add_handler(replace_template_conv)
+application.add_handler(template_card_cb)
+application.add_handler(template_toggle_cb)
+application.add_handler(template_delete_cb)
+application.add_handler(template_list_cb)
 application.add_handler(MessageHandler(filters.Regex("^📄 Шаблони договорів$"), admin_templates_handler))
+application.add_handler(MessageHandler(filters.Regex("^📋 Список шаблонів$"), show_templates_cb))
 application.add_handler(MessageHandler(filters.Regex("^👥 Користувачі$"), admin_users_handler))
 application.add_handler(MessageHandler(filters.Regex("^🗑️ Видалення об’єктів$"), admin_delete_handler))
 application.add_handler(MessageHandler(filters.Regex("^↩️ Головне меню$"), to_main_menu))


### PR DESCRIPTION
## Summary
- add AgreementTemplate table and helper functions
- manage templates via new admin menu
- allow uploading/activating template files using FTP

## Testing
- `python -m py_compile dialogs/agreement_template.py handlers/menu.py main.py db.py keyboards/menu.py`

------
https://chatgpt.com/codex/tasks/task_e_6886395268f48321817003f4da2390c6