### PR TITLE
Add variables reference in templates admin

### DIFF
--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -24,7 +24,9 @@ from db import (
 )
 from dialogs.agreement_template import (
     show_templates_cb, add_template_conv, replace_template_conv,
-    template_card_cb, template_toggle_cb, template_delete_cb, template_list_cb
+    template_card_cb, template_toggle_cb, template_delete_cb, template_list_cb,
+    template_vars_cb, template_vars_categories_cb, template_var_list_cb,
+    copy_var_cb
 )
 
 (
@@ -187,6 +189,7 @@ async def admin_templates_handler(update, context):
         await msg.reply_text("Менеджмент шаблонів договорів:", reply_markup=admin_templates_menu)
     else:
         await show_templates_cb(update, context)
+
 
 @admin_only
 async def admin_users_handler(update, context):

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -118,6 +118,7 @@ admin_tov_menu = ReplyKeyboardMarkup(
 admin_templates_menu = ReplyKeyboardMarkup(
     [
         ["➕ Додати шаблон", "📋 Список шаблонів"],
+        ["📘 Переглянути список змінних"],
         ["↩️ Адмінпанель"]
     ],
     resize_keyboard=True

--- a/main.py
+++ b/main.py
@@ -35,7 +35,9 @@ from dialogs.edit_company import edit_company_conv
 from dialogs.agreement_template import (
     add_template_conv, replace_template_conv,
     template_card_cb, template_toggle_cb, template_delete_cb,
-    template_list_cb, show_templates_cb
+    template_list_cb, show_templates_cb,
+    template_vars_cb, template_vars_categories_cb, template_var_list_cb,
+    copy_var_cb
 )
 
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -128,6 +130,10 @@ application.add_handler(template_card_cb)
 application.add_handler(template_toggle_cb)
 application.add_handler(template_delete_cb)
 application.add_handler(template_list_cb)
+application.add_handler(template_vars_cb)
+application.add_handler(template_vars_categories_cb)
+application.add_handler(template_var_list_cb)
+application.add_handler(copy_var_cb)
 application.add_handler(MessageHandler(filters.Regex("^📄 Шаблони договорів$"), admin_templates_handler))
 application.add_handler(MessageHandler(filters.Regex("^📋 Список шаблонів$"), show_templates_cb))
 application.add_handler(MessageHandler(filters.Regex("^👥 Користувачі$"), admin_users_handler))

--- a/template_vars.py
+++ b/template_vars.py
@@ -1,0 +1,43 @@
+TEMPLATE_VARIABLES = {
+    "payer": {
+        "title": "PAYOVYK",
+        "items": [
+            ("{{payer_full_name}}", "ПІБ"),
+            ("{{payer_passport}}", "паспортні дані"),
+            ("{{payer_tax_code}}", "ІПН"),
+            ("{{payer_address}}", "адреса"),
+            ("{{payer_phone}}", "телефон"),
+            ("{{payer_birth_date}}", "дата народження"),
+        ],
+    },
+    "agreement": {
+        "title": "AGREEMENT",
+        "items": [
+            ("{{agreement_number}}", "номер"),
+            ("{{agreement_date}}", "дата підписання"),
+            ("{{agreement_start}}", "дата початку дії"),
+            ("{{agreement_end}}", "дата завершення дії"),
+            ("{{agreement_type}}", "тип договору"),
+            ("{{agreement_notes}}", "нотатки"),
+        ],
+    },
+    "land": {
+        "title": "LAND",
+        "items": [
+            ("{{land_list}}", "список кадастрових номерів"),
+            ("{{land_table}}", "HTML-таблиця ділянок (№, площа, НГО)"),
+            ("{{total_area}}", "сумарна площа, га"),
+        ],
+    },
+    "company": {
+        "title": "COMPANY",
+        "items": [
+            ("{{company_name}}", "назва ТОВ"),
+            ("{{company_director}}", "директор"),
+            ("{{company_code}}", "ЄДРПОУ"),
+            ("{{company_address}}", "адреса"),
+            ("{{company_iban}}", "рахунок"),
+            ("{{company_phone}}", "телефон"),
+        ],
+    },
+}


### PR DESCRIPTION
## Summary
- add `template_vars.py` with grouped template variables
- show variables list via inline menus and copy buttons
- update keyboards to include a 'view variables' option
- wire handlers and routes for new variable list commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886420bacfc832187f0df92772d0b45