### PR TITLE
Instant document upload prompt

### DIFF
--- a/dialogs/add_docs_fsm.py
+++ b/dialogs/add_docs_fsm.py
@@ -63,6 +63,8 @@ def repack_pdf(input_path, output_path):
 
 async def start_add_docs(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
+    context.user_data.pop("post_create_msg", None)
+    context.user_data.pop("post_create_markup", None)
     _, entity_type, entity_id = query.data.split(":")
     context.user_data["entity_type"] = entity_type
     context.user_data["entity_id"] = entity_id

--- a/dialogs/field.py
+++ b/dialogs/field.py
@@ -6,6 +6,7 @@ from telegram.ext import (
 )
 from keyboards.menu import fields_menu
 from db import database, Field, UploadedDocs
+from dialogs.post_creation import prompt_add_docs
 import sqlalchemy
 from ftp_utils import download_file_ftp, delete_file_ftp  # <-- додаємо FTP-утиліти
 
@@ -42,12 +43,17 @@ async def add_field_area(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return ASK_FIELD_AREA
     name = context.user_data["field_name"]
     query = Field.insert().values(name=name, area_actual=area)
-    await database.execute(query)
-    await update.message.reply_text(
-        f"Поле '{name}' ({area:.4f} га) додано.",
-        reply_markup=fields_menu
-    )
+    field_id = await database.execute(query)
+
     context.user_data.clear()
+    await prompt_add_docs(
+        update,
+        context,
+        "field",
+        field_id,
+        f"Поле '{name}' ({area:.4f} га) додано.",
+        fields_menu,
+    )
     return ConversationHandler.END
 
 add_field_conv = ConversationHandler(

--- a/dialogs/land.py
+++ b/dialogs/land.py
@@ -9,6 +9,7 @@ from telegram.ext import (
 )
 from keyboards.menu import lands_menu
 from db import database, LandPlot, Field, Payer, UploadedDocs
+from dialogs.post_creation import prompt_add_docs
 import sqlalchemy
 from ftp_utils import download_file_ftp, delete_file_ftp
 
@@ -97,9 +98,17 @@ async def choose_payer(update: Update, context: ContextTypes.DEFAULT_TYPE):
             field_id=context.user_data["field_id"],
             payer_id=None
         )
-        await database.execute(query)
-        await update.message.reply_text("Ділянка додана без власника! Власника можна додати в картці ділянки.", reply_markup=lands_menu)
+        land_id = await database.execute(query)
+
         context.user_data.clear()
+        await prompt_add_docs(
+            update,
+            context,
+            "land",
+            land_id,
+            "Ділянка додана без власника! Власника можна додати в картці ділянки.",
+            lands_menu,
+        )
         return ConversationHandler.END
 
     payers = await database.fetch_all(sqlalchemy.select(Payer).limit(20))
@@ -126,9 +135,17 @@ async def set_payer(update: Update, context: ContextTypes.DEFAULT_TYPE):
         field_id=context.user_data["field_id"],
         payer_id=payer_id
     )
-    await database.execute(query)
-    await update.message.reply_text("Ділянка додана!", reply_markup=lands_menu)
+    land_id = await database.execute(query)
+
     context.user_data.clear()
+    await prompt_add_docs(
+        update,
+        context,
+        "land",
+        land_id,
+        "Ділянка додана!",
+        lands_menu,
+    )
     return ConversationHandler.END
 
 add_land_conv = ConversationHandler(

--- a/dialogs/payer.py
+++ b/dialogs/payer.py
@@ -10,6 +10,7 @@ from telegram.ext import (
 )
 from telegram.constants import ParseMode
 from db import database, Payer, UploadedDocs
+from dialogs.post_creation import prompt_add_docs
 from keyboards.menu import payers_menu, main_menu
 from ftp_utils import download_file_ftp, delete_file_ftp
 
@@ -308,14 +309,22 @@ async def add_payer_birth_date(update: Update, context: ContextTypes.DEFAULT_TYP
         birth_date=d.get("birth_date"),
     )
     payer_id = await database.execute(query)
-    keyboard = [
+
+    keyboard = InlineKeyboardMarkup([
         [InlineKeyboardButton("Створити договір оренди", callback_data=f"create_contract:{payer_id}")],
-        [InlineKeyboardButton("До меню", callback_data="to_menu")]
-    ]
-    await update.message.reply_text(
-        f"✅ Пайовика додано!", reply_markup=InlineKeyboardMarkup(keyboard)
-    )
+        [InlineKeyboardButton("До меню", callback_data="to_menu")],
+    ])
+    final_text = "✅ Пайовика додано!"
+
     context.user_data.clear()
+    await prompt_add_docs(
+        update,
+        context,
+        "payer_passport" if d.get("doc_type") == "passport" else "payer_id",
+        payer_id,
+        final_text,
+        keyboard,
+    )
     return ConversationHandler.END
 
 # ==== СПИСОК, КАРТКА, РЕДАГУВАННЯ, ВИДАЛЕННЯ ====

--- a/dialogs/post_creation.py
+++ b/dialogs/post_creation.py
@@ -1,0 +1,55 @@
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardMarkup
+from telegram.ext import ContextTypes
+
+
+async def prompt_add_docs(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    entity_type: str,
+    entity_id: int,
+    final_text: str,
+    final_markup,
+):
+    """Ask user to upload documents right after object creation."""
+
+    context.user_data["post_create_msg"] = final_text
+    context.user_data["post_create_markup"] = final_markup
+
+    await update.message.reply_text(
+        "✅ Об’єкт створено.\n📎 Бажаєте одразу додати документи?",
+        reply_markup=InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "Додати зараз",
+                        callback_data=f"add_docs:{entity_type}:{entity_id}",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        "Пропустити",
+                        callback_data=f"skip_docs:{entity_type}:{entity_id}",
+                    )
+                ],
+            ]
+        ),
+    )
+
+
+async def skip_add_docs(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Return to the stored message when user skips document upload."""
+
+    query = update.callback_query
+    await query.answer()
+
+    text = context.user_data.pop("post_create_msg", "")
+    markup = context.user_data.pop("post_create_markup", None)
+
+    if isinstance(markup, ReplyKeyboardMarkup):
+        await query.message.delete()
+        await query.message.reply_text(text, reply_markup=markup)
+    else:
+        await query.message.edit_text(text, reply_markup=markup)
+
+    context.user_data.clear()
+

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from dialogs.edit_field import edit_field_conv
 from dialogs.edit_land import edit_land_conv
 from dialogs.edit_land_owner import edit_land_owner_conv
 from dialogs.add_docs_fsm import add_docs_conv, send_pdf, delete_pdf  # тільки FTP!
+from dialogs.post_creation import skip_add_docs
 from db import database, ensure_admin
 
 from dialogs.admin_tov import admin_tov_add_conv
@@ -112,6 +113,7 @@ application.add_handler(edit_company_conv)
 application.add_handler(add_docs_conv)
 application.add_handler(CallbackQueryHandler(send_pdf, pattern=r"^send_pdf:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_pdf, pattern=r"^delete_pdf_db:\d+$"))
+application.add_handler(CallbackQueryHandler(skip_add_docs, pattern=r"^skip_docs:\w+:\d+$"))
 
 # CallbackQueryHandler-и — як є, доки не переведені на нову систему:
 application.add_handler(CallbackQueryHandler(payer_card, pattern=r"^payer_card:"))


### PR DESCRIPTION
## Summary
- offer to upload documents right after creating payers, lands and fields
- clean up temporary context when starting document upload
- provide helper to build upload prompt and handle skip action
- register skip handler in the main app

## Testing
- `python -m py_compile dialogs/post_creation.py dialogs/payer.py dialogs/land.py dialogs/field.py dialogs/add_docs_fsm.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688646b6346883219afba8a7d4af231e