### PR TITLE
Implement cadastral search for contract FSM

### DIFF
--- a/dialogs/search.py
+++ b/dialogs/search.py
@@ -1,10 +1,19 @@
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ConversationHandler, MessageHandler, CommandHandler, filters, ContextTypes
 from dialogs.payer import to_menu
-from db import database, Payer
+from db import database, Payer, LandPlot
+import sqlalchemy
 import re
 
+
+def format_cadaster(text: str) -> str | None:
+    digits = re.sub(r"\D", "", text)
+    if len(digits) != 19:
+        return None
+    return f"{digits[:10]}:{digits[10:12]}:{digits[12:15]}:{digits[15:]}"
+
 SEARCH_INPUT = 1001  # Унікальний стан пошуку
+SEARCH_LAND_INPUT = 1002
 
 async def payer_search_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("Введіть ID, ІПН, телефон або фрагмент ПІБ для пошуку пайовика:")
@@ -52,6 +61,38 @@ search_payer_conv = ConversationHandler(
     entry_points=[MessageHandler(filters.Regex("^🔍 Пошук пайовика$"), payer_search_start)],
     states={
         SEARCH_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, payer_search_do)],
+    },
+    fallbacks=[CommandHandler("start", to_menu)],
+)
+
+
+async def land_search_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text("Введіть кадастровий номер ділянки:")
+    return SEARCH_LAND_INPUT
+
+
+async def land_search_do(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    cad = format_cadaster(update.message.text)
+    if not cad:
+        await update.message.reply_text("Некоректний номер. Спробуйте ще:")
+        return SEARCH_LAND_INPUT
+    row = await database.fetch_one(sqlalchemy.select(LandPlot).where(LandPlot.c.cadaster == cad))
+    if not row:
+        await update.message.reply_text("Ділянку не знайдено.")
+        return ConversationHandler.END
+    btn = InlineKeyboardButton("Картка", callback_data=f"land_card:{row['id']}")
+    add_btn = InlineKeyboardButton("➕ Додати до договору", callback_data=f"add_land_to_contract:{row['id']}")
+    await update.message.reply_text(
+        f"{row['id']}. {row['cadaster']} — {row['area']:.4f} га",
+        reply_markup=InlineKeyboardMarkup([[btn, add_btn]]),
+    )
+    return ConversationHandler.END
+
+
+search_land_conv = ConversationHandler(
+    entry_points=[MessageHandler(filters.Regex("^🔍 Пошук ділянки$"), land_search_start)],
+    states={
+        SEARCH_LAND_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, land_search_do)],
     },
     fallbacks=[CommandHandler("start", to_menu)],
 )

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from dialogs.payer import (
     to_menu
 )
 from dialogs.edit_payer import edit_payer_conv
-from dialogs.search import search_payer_conv
+from dialogs.search import search_payer_conv, search_land_conv
 from dialogs.field import add_field_conv, show_fields, delete_field, delete_field_prompt, to_fields_list, field_card, edit_field
 from dialogs.land import add_land_conv, show_lands, land_card, delete_land, delete_land_prompt, to_lands_list
 from dialogs.contract import add_contract_conv, show_contracts, contract_card, to_contracts, send_contract_pdf
@@ -90,6 +90,7 @@ application.add_handler(MessageHandler(filters.Regex("^🛡️ Адмінпан�
 application.add_handler(add_payer_conv)
 application.add_handler(MessageHandler(filters.Regex("^📋 Список пайовиків$"), show_payers))
 application.add_handler(search_payer_conv)
+application.add_handler(search_land_conv)
 application.add_handler(edit_payer_conv)
 
 # --- ДІЛЯНКИ/ПОЛЯ ---


### PR DESCRIPTION
## Summary
- enable cadastral search and add button to include found land in contract
- keep track of selected land parcels during contract creation
- register new land search dialog

## Testing
- `python -m py_compile dialogs/contract.py dialogs/search.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68866fe4778083218ea581d9aaeab298