### PR TITLE
Add payer tax ID and birthdate variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ manually.
 
 ### Payer
 - `{{payer_name}}` — ПІБ пайовика
+- `{{payer_tax_id}}` — ІПН пайовика
+- `{{payer_birthdate}}` — Дата народження пайовика
 - `{{payer_passport}}` — Паспортні дані пайовика
 - `{{payer_address}}` — Адреса проживання пайовика
 - `{{payer_share}}` — Частка власності пайовика

--- a/dialogs/agreement_template.py
+++ b/dialogs/agreement_template.py
@@ -11,6 +11,15 @@ from db import (
     update_agreement_template, delete_agreement_template
 )
 from template_vars import TEMPLATE_VARIABLES
+
+
+def _build_all_vars_text() -> str:
+    """Return full list of available template variables."""
+    sections = []
+    for cat in TEMPLATE_VARIABLES.values():
+        lines = [f"<code>{v}</code> → {d}" for v, d in cat["items"]]
+        sections.append(f"<b>{cat['title']}</b>:\n" + "\n".join(lines))
+    return "\n\n".join(sections)
 import re
 import zipfile
 import unicodedata
@@ -100,40 +109,12 @@ async def show_templates_cb(update, context):
 
 
 async def template_vars_categories(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Show list of template variable categories."""
-    text = (
-        "<b>Список змінних</b>\n"
-        "Оберіть категорію. Якщо значення порожнє, у документі буде "
-        "\"<code>______________________</code>\" для ручного заповнення:"
-    )
-    keyboard = [
-        [InlineKeyboardButton(cat["title"], callback_data=f"varcat:{key}")]
-        for key, cat in TEMPLATE_VARIABLES.items()
-    ]
-    keyboard.append([InlineKeyboardButton("↩️ Назад", callback_data="template_list")])
-    msg = update.callback_query if update.callback_query else update.message
+    """Send full list of template variables in one message."""
+    text = _build_all_vars_text()
     if update.callback_query:
-        await update.callback_query.edit_message_text(
-            text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML"
-        )
+        await update.callback_query.edit_message_text(text, parse_mode="HTML")
     else:
-        await update.message.reply_text(
-            text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML"
-        )
-
-
-def _build_vars_text(cat_key: str) -> str:
-    cat = TEMPLATE_VARIABLES[cat_key]
-    lines = [f"<code>{v}</code> — {d}" for v, d in cat["items"]]
-    return f"<b>{cat['title']}</b>\n" + "\n".join(lines)
-
-
-async def template_vars_list(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    query = update.callback_query
-    cat_key = query.data.split(":")[1]
-    text = _build_vars_text(cat_key)
-    keyboard = [[InlineKeyboardButton("↩️ Категорії", callback_data="template_vars")]]
-    await query.edit_message_text(text, reply_markup=InlineKeyboardMarkup(keyboard), parse_mode="HTML")
+        await update.message.reply_text(text, parse_mode="HTML")
 
 async def template_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
@@ -314,4 +295,3 @@ template_delete_cb = CallbackQueryHandler(template_delete, pattern=r"^template_d
 template_list_cb = CallbackQueryHandler(show_templates_cb, pattern=r"^template_list$")
 template_vars_cb = MessageHandler(filters.Regex("^📘 Переглянути список змінних$"), template_vars_categories)
 template_vars_categories_cb = CallbackQueryHandler(template_vars_categories, pattern=r"^template_vars$")
-template_var_list_cb = CallbackQueryHandler(template_vars_list, pattern=r"^varcat:\w+$")

--- a/dialogs/payer.py
+++ b/dialogs/payer.py
@@ -356,19 +356,19 @@ async def payer_card(update, context):
         await query.answer("Пайовик не знайдений!")
         return ConversationHandler.END
 
-    text = f"""<b>Картка пайовика</b>
-ID: {payer.id}
-ПІБ: {payer.name}
-ІПН: {payer.ipn}
-Адреса: {payer.oblast} обл., {payer.rayon} р-н, с. {payer.selo}, вул. {payer.vul}, буд. {payer.bud}, кв. {payer.kv}
-Телефон: {payer.phone}
-Тип документа: {payer.doc_type}
-Паспорт/ID: {payer.passport_series or ''} {payer.passport_number or ''} {payer.id_number or ''}
-Ким виданий: {payer.passport_issuer or payer.idcard_issuer or ''}
-Коли виданий: {payer.passport_date or payer.idcard_date or ''}
-УНЗР: {payer.unzr or '-'}
-Дата народження: {payer.birth_date}
-"""
+    text = (
+        f"<b>{payer.name}</b>\n"
+        f"🆔 ID: {payer.id}\n"
+        f"📇 ІПН: {payer.ipn}\n"
+        f"🎂 Дата народження: {payer.birth_date}\n"
+        f"📞 Телефон: {payer.phone}\n"
+        f"📑 Тип документа: {payer.doc_type}\n"
+        f"🛂 Паспорт/ID: {payer.passport_series or ''} {payer.passport_number or ''} {payer.id_number or ''}\n"
+        f"Ким виданий: {payer.passport_issuer or payer.idcard_issuer or ''}\n"
+        f"Коли виданий: {payer.passport_date or payer.idcard_date or ''}\n"
+        f"УНЗР: {payer.unzr or '-'}\n"
+        f"🏠 Адреса: {payer.oblast} обл., {payer.rayon} р-н, с. {payer.selo}, вул. {payer.vul}, буд. {payer.bud}, кв. {payer.kv}"
+    )
 
     keyboard = []
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ from dialogs.agreement_template import (
     add_template_conv, replace_template_conv,
     template_card_cb, template_toggle_cb, template_delete_cb,
     template_list_cb, show_templates_cb,
-    template_vars_cb, template_vars_categories_cb, template_var_list_cb
+    template_vars_cb, template_vars_categories_cb
 )
 
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -145,7 +145,6 @@ application.add_handler(template_delete_cb)
 application.add_handler(template_list_cb)
 application.add_handler(template_vars_cb)
 application.add_handler(template_vars_categories_cb)
-application.add_handler(template_var_list_cb)
 application.add_handler(MessageHandler(filters.Regex("^📄 Шаблони договорів$"), admin_templates_handler))
 application.add_handler(MessageHandler(filters.Regex("^📋 Список шаблонів$"), show_templates_cb))
 application.add_handler(MessageHandler(filters.Regex("^👥 Користувачі$"), admin_users_handler))

--- a/template_vars.py
+++ b/template_vars.py
@@ -3,6 +3,12 @@
 # Default placeholder to use when a value is missing
 EMPTY_VALUE = "______________________"
 
+MONTHS_UA = [
+    "січня", "лютого", "березня", "квітня",
+    "травня", "червня", "липня", "серпня",
+    "вересня", "жовтня", "листопада", "грудня",
+]
+
 TEMPLATE_VARIABLES = {
     "company": {
         "title": "ТОВ",
@@ -30,6 +36,8 @@ TEMPLATE_VARIABLES = {
         "title": "Пайовики",
         "items": [
             ("{{payer_name}}", "ПІБ пайовика"),
+            ("{{payer_tax_id}}", "ІПН"),
+            ("{{payer_birthdate}}", "Дата народження"),
             ("{{payer_passport}}", "Паспортні дані"),
             ("{{payer_address}}", "Адреса"),
             ("{{payer_share}}", "Частка"),
@@ -62,4 +70,18 @@ def with_default(value: str | None) -> str:
     if value is None or (isinstance(value, str) and not value.strip()):
         return EMPTY_VALUE
     return value
+
+
+def date_to_words(date_str: str | None) -> str:
+    """Convert DD.MM.YYYY to 'DD <month> YYYY' in Ukrainian."""
+    if not date_str:
+        return EMPTY_VALUE
+    try:
+        from datetime import datetime
+
+        dt = datetime.strptime(date_str, "%d.%m.%Y")
+    except Exception:
+        return date_str
+    month_name = MONTHS_UA[dt.month - 1]
+    return f"{dt.day} {month_name} {dt.year}"
 


### PR DESCRIPTION
## Summary
- extend template variables for payer section
- display payer tax ID and birth date in the card
- show full variable list in a single message
- document new template variables
- show all payer fields in the card

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6887436973c08321ba585b00d3c0d8e5