### PR TITLE
Fix missing import

### DIFF
--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -27,7 +27,7 @@ from db import (
 from dialogs.agreement_template import (
     show_templates_cb, add_template_conv, replace_template_conv,
     template_card_cb, template_toggle_cb, template_delete_cb, template_list_cb,
-    template_vars_cb, template_vars_categories_cb, template_var_list_cb
+    template_vars_cb, template_vars_categories_cb
 )
 
 (


### PR DESCRIPTION
## Summary
- fix import list in menu handler causing runtime crash

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6887493ee2508321a240dc9cd6354ba9