### PR TITLE
Fix missing rent_amount column

### DIFF
--- a/db.py
+++ b/db.py
@@ -305,4 +305,7 @@ with engine.begin() as conn:
     conn.execute(sqlalchemy.text(
         'ALTER TABLE "payer" ADD COLUMN IF NOT EXISTS bank_card VARCHAR'
     ))
+    conn.execute(sqlalchemy.text(
+        'ALTER TABLE "contract" ADD COLUMN IF NOT EXISTS rent_amount NUMERIC(12,2)'
+    ))
 


### PR DESCRIPTION
## Summary
- add DB migration for `rent_amount` column in `contract`

## Testing
- `python -m py_compile db.py dialogs/contract.py`


------
https://chatgpt.com/codex/tasks/task_e_688765578498832198f1eff2ab67e462