### PR TITLE
Handle duplicate template variables

### DIFF
--- a/contract_pdf.py
+++ b/contract_pdf.py
@@ -11,6 +11,7 @@ from docxtpl import DocxTemplate
 from docx2pdf import convert
 
 from template_vars import with_default, date_to_words
+from template_utils import extract_variables
 
 
 def format_area(area: float | int | str | None) -> str:
@@ -83,7 +84,9 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
 
 def render_template(template_path: str, context: Mapping[str, Any], output_dir: str) -> str:
     doc = DocxTemplate(template_path)
-    doc.render(context)
+    vars_in_template = extract_variables(template_path)
+    used_context = {var: context.get(var) for var in vars_in_template}
+    doc.render(used_context)
     os.makedirs(output_dir, exist_ok=True)
     docx_path = os.path.join(output_dir, "contract.docx")
     doc.save(docx_path)

--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -759,8 +759,14 @@ async def generate_contract_pdf_cb(update: Update, context: ContextTypes.DEFAULT
         "today": datetime.utcnow().strftime("%d.%m.%Y"),
         "year": datetime.utcnow().year,
     }
-    missing, unsupported, total = analyze_template(tmp_doc, variables)
-    msg = build_unresolved_message(missing, unsupported, total)
+    missing, unsupported, total, filled, _ = analyze_template(tmp_doc, variables)
+    msg = build_unresolved_message(
+        missing,
+        unsupported,
+        total,
+        filled=filled,
+        template_name=os.path.basename(template["file_path"]),
+    )
     if msg:
         await query.message.reply_text(msg)
     try:

--- a/template_utils.py
+++ b/template_utils.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Iterable
+from typing import Any, Mapping, Iterable, Dict
+
+import re
+import zipfile
+from collections import Counter
 
 from docxtpl import DocxTemplate
 
@@ -23,9 +27,31 @@ def find_unsupported_vars(template_path: str) -> list[str]:
     return sorted(found - ALLOWED_VARS)
 
 
+def extract_variables(path: str) -> Dict[str, int]:
+    """Return mapping of variables found in DOCX to their occurrence count."""
+    text_parts: list[str] = []
+    with zipfile.ZipFile(path) as z:
+        for name in z.namelist():
+            if name.startswith("word/") and name.endswith(".xml"):
+                xml = z.read(name).decode("utf-8", errors="ignore")
+                cleaned = re.sub(r"<[^>]+>", "", xml)
+                text_parts.append(cleaned)
+
+    full_text = "".join(text_parts)
+    raw_vars = re.findall(r"\{\{.*?\}\}", full_text)
+
+    counter: Counter[str] = Counter()
+    for var in raw_vars:
+        inner = re.sub(r"[^\w]", "", var[2:-2])
+        if inner:
+            counter[inner] += 1
+
+    return dict(counter)
+
+
 def analyze_template(
     template_path: str, context: Mapping[str, Any]
-) -> tuple[list[str], list[str], int]:
+) -> tuple[list[str], list[str], int, int, Dict[str, int]]:
     """Return missing and unsupported placeholders for a template.
 
     Parameters
@@ -37,48 +63,65 @@ def analyze_template(
 
     Returns
     -------
-    tuple[list[str], list[str], int]
+    tuple[list[str], list[str], int, int, Dict[str, int]]
         First item is a list of supported placeholders with empty values,
         second item is a list of unsupported placeholders.
         Third item is the total number of placeholders found in the template.
+        Fourth item is the number of placeholders successfully filled.
+        Fifth item is mapping of variable names to how many times they appear.
     """
-    doc = DocxTemplate(template_path)
-    vars_found = list(doc.get_undeclared_template_variables())
-    all_vars = {f"{{{{{v}}}}}" for v in vars_found}
-    missing_in_ctx = {
-        f"{{{{{v}}}}}" for v in doc.get_undeclared_template_variables(context=context)
-    }
-    missing_values = {
-        f"{{{{{k}}}}}"
-        for k, v in context.items()
-        if (v is None or (isinstance(v, str) and not str(v).strip()))
-        and f"{{{{{k}}}}}" in all_vars
-    }
-    unsupported = sorted(all_vars - ALLOWED_VARS)
-    supported_missing = sorted((missing_in_ctx | missing_values) & ALLOWED_VARS)
-    total = len(all_vars)
-    return supported_missing, unsupported, total
+    counts = extract_variables(template_path)
+    missing: list[str] = []
+    unsupported: list[str] = []
+    filled = 0
+    for var, cnt in counts.items():
+        if var not in SUPPORTED_VARS:
+            unsupported.append(f"{{{{{var}}}}}")
+            continue
+        value = context.get(var)
+        if value is None or (isinstance(value, str) and not str(value).strip()):
+            missing.append(f"{{{{{var}}}}}")
+        else:
+            filled += cnt
+    total = sum(counts.values())
+    missing.sort()
+    unsupported.sort()
+    return missing, unsupported, total, filled, counts
 
 
 def build_unresolved_message(
-    missing: Iterable[str], unsupported: Iterable[str], total: int
+    missing: Iterable[str],
+    unsupported: Iterable[str],
+    total: int,
+    *,
+    filled: int | None = None,
+    template_name: str | None = None,
 ) -> str:
     """Format message listing unresolved placeholders."""
     missing = list(missing)
     unsupported = list(unsupported)
-    if not missing and not unsupported:
-        return f"✅ Усі {total} змінних знайдено та заповнено"
 
-    lines = ["⚠️ У шаблоні знайдено незаповнені змінні:", ""]
+    if not missing and not unsupported:
+        if filled is not None:
+            return f"✅ Усі {total} змінних знайдено та заповнено"
+        return ""
+
+    name_part = f" {template_name}" if template_name else ""
+    header = f"⚠️ У шаблоні{name_part} знайдено {total} змінних"
+    lines = [header]
+    if filled is not None:
+        lines.append(f"✅ Заповнено: {filled}")
+    lines.append("❌ Не заповнено:")
+
     for var in sorted(missing + unsupported):
         if var in unsupported:
             lines.append(f"{var} — змінна не підтримується")
         else:
             desc = VAR_DESCRIPTIONS.get(var, "")
             if desc:
-                lines.append(f"{var} — значення відсутнє ({desc} не вказано)")
+                lines.append(f"{var} — {desc} не вказано")
             else:
                 lines.append(f"{var} — значення відсутнє")
-    lines.append(f"📎 У шаблон буде підставлено: {EMPTY_VALUE}")
+    lines.append(f"📝 У шаблон буде підставлено: {EMPTY_VALUE}")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- parse DOCX templates manually to detect all variables with duplicates
- count how many placeholders are filled or missing
- include template name and counts in unresolved variables message
- render templates using only variables actually present in the document

## Testing
- `python -m py_compile template_utils.py contract_pdf.py dialogs/contract.py dialogs/agreement_template.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688780d954d483219fbebd99f914e9a7