### PR TITLE
Fix contract data linking for PDF generation

### DIFF
--- a/db.py
+++ b/db.py
@@ -75,6 +75,7 @@ Contract = sqlalchemy.Table(
     metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("company_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("company.id")),
+    sqlalchemy.Column("payer_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("payer.id")),
     sqlalchemy.Column("number", sqlalchemy.String(32)),
     sqlalchemy.Column("date_signed", sqlalchemy.DateTime),
     sqlalchemy.Column("date_valid_from", sqlalchemy.DateTime),
@@ -307,5 +308,8 @@ with engine.begin() as conn:
     ))
     conn.execute(sqlalchemy.text(
         'ALTER TABLE "contract" ADD COLUMN IF NOT EXISTS rent_amount NUMERIC(12,2)'
+    ))
+    conn.execute(sqlalchemy.text(
+        'ALTER TABLE "contract" ADD COLUMN IF NOT EXISTS payer_id INTEGER REFERENCES payer(id)'
     ))
 


### PR DESCRIPTION
## Summary
- add `payer_id` column to `Contract`
- ensure column exists with `ALTER TABLE`
- store chosen payer when saving contract
- fetch payer, company and plots for a contract when generating PDF
- include payer and plot details in template variables

## Testing
- `python -m py_compile dialogs/contract.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_688786d9d7a88321ac9eba0b16bd77c9