### PR TITLE
Ensure PDF generation continues with missing variables

### DIFF
--- a/contract_pdf.py
+++ b/contract_pdf.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping
 from docxtpl import DocxTemplate
 from docx2pdf import convert
 
-from template_vars import with_default, date_to_words
+from template_vars import with_default, date_to_words, EMPTY_VALUE
 from template_utils import extract_variables
 
 
@@ -85,7 +85,13 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
 def render_template(template_path: str, context: Mapping[str, Any], output_dir: str) -> str:
     doc = DocxTemplate(template_path)
     vars_in_template = extract_variables(template_path)
-    used_context = {var: context.get(var) for var in vars_in_template}
+    used_context = {}
+    for var in vars_in_template:
+        value = context.get(var)
+        if value is None or (isinstance(value, str) and not str(value).strip()):
+            used_context[var] = EMPTY_VALUE
+        else:
+            used_context[var] = value
     doc.render(used_context)
     os.makedirs(output_dir, exist_ok=True)
     docx_path = os.path.join(output_dir, "contract.docx")

--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -826,7 +826,11 @@ async def generate_contract_pdf_cb(update: Update, context: ContextTypes.DEFAULT
         filled=filled,
         template_name=os.path.basename(template["file_path"]),
     )
-    if msg:
+    if missing:
+        await query.message.reply_text(
+            "⚠️ Частина змінних не була заповнена, у шаблон підставлено порожні рядки\nPDF сформовано успішно"
+        )
+    elif msg:
         await query.message.reply_text(msg)
     try:
         remote_path = generate_contract(


### PR DESCRIPTION
## Summary
- fill undefined template variables with underscores
- warn user if variables are missing when generating contract PDFs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68878b5254388321a25514131eb6fe59