### PR TITLE
fix/template-variable-validation-priority

### DIFF
--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -826,11 +826,7 @@ async def generate_contract_pdf_cb(update: Update, context: ContextTypes.DEFAULT
         filled=filled,
         template_name=os.path.basename(template["file_path"]),
     )
-    if missing:
-        await query.message.reply_text(
-            "⚠️ Частина змінних не була заповнена, у шаблон підставлено порожні рядки\nPDF сформовано успішно"
-        )
-    elif msg:
+    if msg:
         await query.message.reply_text(msg)
     try:
         remote_path = generate_contract(


### PR DESCRIPTION
## Summary
- always display template variable info before PDF generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887941ab7608321a62ed56c7f02760a