### PR TITLE
Fix template handling in contract generation

### DIFF
--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -324,18 +324,16 @@ async def generate_contract_v2(contract_id: int) -> tuple[str, str]:
 
     # Analyze template for unresolved placeholders (result not used yet)
     analyze_template(tmp_doc, variables)
+    if os.path.exists(tmp_doc):
+        os.remove(tmp_doc)
 
-    try:
-        remote_path, gen_log = generate_contract(
-            tmp_doc,
-            variables,
-            payer_name=payer["name"],
-            contract_number=contract["number"],
-            year=datetime.utcnow().year,
-        )
-    finally:
-        if os.path.exists(tmp_doc):
-            os.remove(tmp_doc)
+    remote_path, gen_log = generate_contract(
+        template["file_path"],
+        variables,
+        payer_name=payer["name"],
+        contract_number=contract["number"],
+        year=datetime.utcnow().year,
+    )
 
     await database.execute(
         UploadedDocs.delete().where(


### PR DESCRIPTION
## Summary
- use `generate_contract` with remote template path
- remove temporary doc once placeholders analyzed

## Testing
- `python -m py_compile contract_generation_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b2f4fff883218a6a1f34af2059f9