### PR TITLE
Fix contract template download directory

### DIFF
--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -279,6 +279,7 @@ async def generate_contract_v2(contract_id: int) -> tuple[str, str]:
     template = templates[0]
 
     tmp_doc = f"temp_docs/template_{contract_id}.docx"
+    os.makedirs("temp_docs", exist_ok=True)
     download_file_ftp(template["file_path"], tmp_doc)
 
     variables = {


### PR DESCRIPTION
## Summary
- ensure `temp_docs` directory exists before downloading agreement templates in `generate_contract_v2`

## Testing
- `python -m py_compile contract_generation_v2.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c1379ad0832197988bca4566e987