### PR TITLE
Add docx conversion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,6 @@ empty.
 
 LibreOffice (``soffice``) must be installed on the system for DOCX→PDF
 conversion. The `docx2pdf` library will automatically attempt to use
-LibreOffice if it is available.
+LibreOffice if it is available. Install ``docx2pdf`` via ``pip install docx2pdf``.
+If LibreOffice is not installed or you prefer another tool, any CLI converter
+such as ``unoconv`` can be used as an alternative.

--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -17,6 +17,21 @@ from decimal import Decimal
 
 
 def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
+    """Convert a DOCX document to PDF.
+
+    The function first attempts to use :func:`docx2pdf.convert`. If this fails
+    (for example on Linux where Microsoft Word is unavailable), it falls back to
+    running LibreOffice in headless mode, provided that ``libreoffice`` or
+    ``soffice`` is installed on the system.
+
+    Parameters
+    ----------
+    docx_path:
+        Path to the source DOCX file.
+    pdf_path:
+        Destination path for the generated PDF file.
+    """
+
     try:
         convert(docx_path, pdf_path)
     except Exception:


### PR DESCRIPTION
## Summary
- document how to install `docx2pdf` and note alternatives
- explain PDF conversion helper with a docstring

## Testing
- `pytest -q`
- `python -m py_compile contract_generation_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c576406083219d61136defa006ac