### PR TITLE
Fix DOCX to PDF fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The call returns `(remote_path, log)` where `remote_path` is the FTP path of the
 uploaded PDF and `log` describes which template placeholders were filled or left
 empty.
 
-LibreOffice (``soffice``) must be installed on the system for DOCX→PDF
-conversion. The `docx2pdf` library will automatically attempt to use
-LibreOffice if it is available. Install ``docx2pdf`` via ``pip install docx2pdf``.
-If LibreOffice is not installed or you prefer another tool, any CLI converter
-such as ``unoconv`` can be used as an alternative.
+LibreOffice (``soffice``) should be installed on the system for DOCX→PDF
+conversion. The helper function first tries :func:`docx2pdf.convert`; if that
+fails it falls back to ``libreoffice`` or, if unavailable, ``unoconv``. Install
+``docx2pdf`` via ``pip install docx2pdf`` and ensure either LibreOffice or
+``unoconv`` is present on the system.

--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -34,24 +34,37 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
 
     try:
         convert(docx_path, pdf_path)
-    except Exception:
+        return
+    except Exception as exc:
         libreoffice = shutil.which("libreoffice") or shutil.which("soffice")
-        if not libreoffice:
-            raise
-        subprocess.run([
-            libreoffice,
-            "--headless",
-            "--convert-to",
-            "pdf",
-            "--outdir",
-            os.path.dirname(pdf_path),
-            docx_path,
-        ], check=True)
-        generated = os.path.join(
-            os.path.dirname(pdf_path),
-            os.path.splitext(os.path.basename(docx_path))[0] + ".pdf",
-        )
-        os.replace(generated, pdf_path)
+        if libreoffice:
+            subprocess.run([
+                libreoffice,
+                "--headless",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                os.path.dirname(pdf_path),
+                docx_path,
+            ], check=True)
+            generated = os.path.join(
+                os.path.dirname(pdf_path),
+                os.path.splitext(os.path.basename(docx_path))[0] + ".pdf",
+            )
+            os.replace(generated, pdf_path)
+            return
+        unoconv = shutil.which("unoconv")
+        if unoconv:
+            subprocess.run([
+                unoconv,
+                "-f",
+                "pdf",
+                "-o",
+                pdf_path,
+                docx_path,
+            ], check=True)
+            return
+        raise exc
 
 
 def format_area(area: float | int | str | None) -> str:


### PR DESCRIPTION
## Summary
- support multiple tools for DOCX→PDF conversion
- document the new fallback logic in README

## Testing
- `python -m py_compile contract_generation_v2.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6887c73856c48321a43e92178ab36f7d