### PR TITLE
Switch to LibreOffice for PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,5 @@ uploaded PDF and `log` describes which template placeholders were filled or left
 empty.
 
 LibreOffice (``soffice``) should be installed on the system for DOCX→PDF
-conversion. The helper function first tries :func:`docx2pdf.convert`; if that
-fails it falls back to ``libreoffice`` or, if unavailable, ``unoconv``. Install
-``docx2pdf`` via ``pip install docx2pdf`` and ensure either LibreOffice or
-``unoconv`` is present on the system.
+conversion. The helper runs ``libreoffice`` in headless mode and falls back to
+``unoconv`` if LibreOffice is unavailable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,3 @@ PyPDF2
 psycopg2-binary>=2.9
 
 docxtpl
-docx2pdf


### PR DESCRIPTION
## Summary
- generate PDFs using `libreoffice` or `unoconv` instead of `docx2pdf`
- document LibreOffice requirement
- remove `docx2pdf` dependency

## Testing
- `python -m py_compile contract_generation_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c95cac048321b5b0774cdce69be6