### PR TITLE
Fix LibreOffice path lookup

### DIFF
--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -30,7 +30,14 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
         Destination path for the generated PDF file.
     """
 
-    libreoffice = shutil.which("libreoffice") or shutil.which("soffice")
+    libreoffice = (
+        os.environ.get("SOFFICE_PATH")
+        or os.environ.get("LIBREOFFICE_PATH")
+        or shutil.which("libreoffice")
+        or shutil.which("soffice")
+        or (os.path.exists("/usr/bin/soffice") and "/usr/bin/soffice")
+        or (os.path.exists("/usr/bin/libreoffice") and "/usr/bin/libreoffice")
+    )
     if libreoffice:
         subprocess.run([
             libreoffice,
@@ -47,7 +54,11 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
         )
         os.replace(generated, pdf_path)
         return
-    unoconv = shutil.which("unoconv")
+    unoconv = (
+        os.environ.get("UNOCONV_PATH")
+        or shutil.which("unoconv")
+        or (os.path.exists("/usr/bin/unoconv") and "/usr/bin/unoconv")
+    )
     if unoconv:
         subprocess.run([
             unoconv,


### PR DESCRIPTION
## Summary
- make `docx_to_pdf` search standard paths for LibreOffice and unoconv
- allow overriding the CLI paths via environment variables

## Testing
- `python -m py_compile contract_generation_v2.py`
- `DEBIAN_FRONTEND=noninteractive apt-get install -y libreoffice`
- `soffice --version`


------
https://chatgpt.com/codex/tasks/task_e_6887cd06abfc8321a37d4360df0e0d9b