### PR TITLE
Add docx2pdf fallback for contract generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,5 @@ empty.
 
 LibreOffice (``soffice``) should be installed on the system for DOCX→PDF
 conversion. The helper runs ``libreoffice`` in headless mode and falls back to
-``unoconv`` if LibreOffice is unavailable.
+``unoconv`` if LibreOffice is unavailable. On Windows or macOS, the optional
+``docx2pdf`` package can be used if Microsoft Word is installed.

--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -5,6 +5,10 @@ import shutil
 from typing import Any, Mapping, Iterable
 
 from docx import Document
+try:
+    from docx2pdf import convert as docx2pdf_convert
+except Exception:  # pragma: no cover - optional dependency
+    docx2pdf_convert = None
 
 from template_vars import SUPPORTED_VARS, EMPTY_VALUE
 from template_utils import extract_variables
@@ -69,8 +73,16 @@ def docx_to_pdf(docx_path: str, pdf_path: str) -> None:
             docx_path,
         ], check=True)
         return
+    if docx2pdf_convert:
+        try:
+            docx2pdf_convert(docx_path, pdf_path)
+            return
+        except NotImplementedError:
+            pass
+        except Exception:
+            pass
     raise RuntimeError(
-        "LibreOffice or unoconv CLI required for DOCX to PDF conversion"
+        "LibreOffice, unoconv or docx2pdf required for DOCX to PDF conversion"
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ PyPDF2
 psycopg2-binary>=2.9
 
 docxtpl
+docx2pdf>=0.1.8


### PR DESCRIPTION
## Summary
- support docx2pdf as a PDF conversion fallback
- document docx2pdf usage in README
- add docx2pdf to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6887d4a53afc8321a5133f461803ea42