### PR TITLE
Add payments menu integration

### DIFF
--- a/dialogs/payment.py
+++ b/dialogs/payment.py
@@ -1,15 +1,28 @@
 from datetime import datetime, date
-from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
+from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton, InputFile
 from telegram.ext import (
     ContextTypes,
     ConversationHandler,
     MessageHandler,
     CallbackQueryHandler,
+    CommandHandler,
     filters,
 )
 import sqlalchemy
 
-from db import database, Contract, Payment
+from dialogs.payer import to_menu
+
+from io import BytesIO, StringIO
+import csv
+
+from db import (
+    database,
+    Contract,
+    Payment,
+    Payer,
+    ContractLandPlot,
+    LandPlot,
+)
 from contract_generation_v2 import format_money
 
 PAY_AMOUNT, PAY_DATE, PAY_TYPE, PAY_NOTES, PAY_CONFIRM = range(5)
@@ -19,6 +32,15 @@ payment_type_map = {
     "card": "\ud83d\udcb3 Картка",
     "bank": "\ud83c\udfe6 Рахунок",
 }
+
+
+def short_fio(full_name: str) -> str:
+    parts = full_name.split()
+    if len(parts) >= 3:
+        return f"{parts[0]} {parts[1][0]}.{parts[2][0]}."
+    if len(parts) == 2:
+        return f"{parts[0]} {parts[1][0]}."
+    return full_name
 
 
 async def add_payment_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -150,4 +172,211 @@ add_payment_conv = ConversationHandler(
         PAY_CONFIRM: [CallbackQueryHandler(payment_save, pattern=r"^payment_save$")],
     },
     fallbacks=[],
+)
+
+
+# ==== ГЛОБАЛЬНИЙ ПОШУК ПАЙОВИКА ====
+SEARCH_PAYER = 2001
+
+
+async def global_add_payment_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text("Введіть частину ПІБ пайовика:")
+    return SEARCH_PAYER
+
+
+async def global_add_payment_search(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    term = update.message.text.strip()
+    rows = await database.fetch_all(
+        sqlalchemy.select(Payer.c.id, Payer.c.name)
+        .where(Payer.c.name.ilike(f"%{term}%"))
+        .limit(10)
+    )
+    if not rows:
+        await update.message.reply_text("Нічого не знайдено. Спробуйте ще:")
+        return SEARCH_PAYER
+    keyboard = [
+        [InlineKeyboardButton(f"\U0001F464 {r['name']}", callback_data=f"pay_select:{r['id']}")]
+        for r in rows
+    ]
+    keyboard.append([InlineKeyboardButton("❌ Скасувати", callback_data="to_menu")])
+    await update.message.reply_text(
+        "Оберіть пайовика:", reply_markup=InlineKeyboardMarkup(keyboard)
+    )
+    return ConversationHandler.END
+
+
+async def select_payer_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    payer_id = int(query.data.split(":")[1])
+    contracts = await database.fetch_all(
+        sqlalchemy.select(
+            Contract.c.id,
+            Contract.c.number,
+            sqlalchemy.func.sum(LandPlot.c.area).label("area"),
+        )
+        .select_from(Contract)
+        .join(ContractLandPlot, Contract.c.id == ContractLandPlot.c.contract_id)
+        .join(LandPlot, LandPlot.c.id == ContractLandPlot.c.land_plot_id)
+        .where(Contract.c.payer_id == payer_id)
+        .group_by(Contract.c.id)
+    )
+    if not contracts:
+        await query.answer("Договори не знайдено!", show_alert=True)
+        return
+    if len(contracts) == 1:
+        cid = contracts[0]["id"]
+        orig = query.data
+        query.data = f"add_payment:{cid}"
+        result = await add_payment_start(update, context)
+        query.data = orig
+        return result
+    keyboard = [
+        [
+            InlineKeyboardButton(
+                f"\U0001F4C4 №{c['number']} ({c['area']:.4f} га)",
+                callback_data=f"pay_contract:{c['id']}",
+            )
+        ]
+        for c in contracts
+    ]
+    await query.message.edit_text("Оберіть договір:", reply_markup=InlineKeyboardMarkup(keyboard))
+
+
+async def select_contract_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    cid = int(query.data.split(":")[1])
+    orig = query.data
+    query.data = f"add_payment:{cid}"
+    result = await add_payment_start(update, context)
+    query.data = orig
+    return result
+
+
+# ==== СПИСОК ОСТАННІХ ВИПЛАТ ====
+async def show_payments(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    msg = update.message if update.message else update.callback_query.message
+    rows = await database.fetch_all(
+        sqlalchemy.select(
+            Payment.c.agreement_id,
+            Payment.c.payment_date,
+            Payment.c.amount,
+            Contract.c.number,
+            Payer.c.name,
+        )
+        .select_from(Payment)
+        .join(Contract, Contract.c.id == Payment.c.agreement_id)
+        .join(Payer, Payer.c.id == Contract.c.payer_id)
+        .order_by(Payment.c.payment_date.desc())
+        .limit(10)
+    )
+    if not rows:
+        await msg.reply_text("Виплати відсутні.")
+        return
+    for r in rows:
+        text = (
+            f"\U0001F4C5 {r['payment_date'].strftime('%d.%m.%Y')} — {format_money(r['amount'])}\n"
+            f"\U0001F464 {short_fio(r['name'])} — \U0001F4C4 №{r['number']}"
+        )
+        btn = InlineKeyboardButton(
+            "\U0001F4DC Детальніше",
+            callback_data=f"agreement_card:{r['agreement_id']}",
+        )
+        await msg.reply_text(text, reply_markup=InlineKeyboardMarkup([[btn]]))
+
+
+# ==== ЗВІТИ ПО ВИПЛАТАХ ====
+async def payment_reports_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    year = datetime.utcnow().year
+    years = [str(year - i) for i in range(3)]
+    kb = InlineKeyboardMarkup(
+        [[InlineKeyboardButton(y, callback_data=f"pay_report:{y}") for y in years]]
+    )
+    await update.message.reply_text("\U0001F4C6 Оберіть рік:", reply_markup=kb)
+
+
+async def payment_report_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    year = int(query.data.split(":")[1])
+    rows = await database.fetch_all(
+        sqlalchemy.select(
+            Contract.c.id,
+            Contract.c.number,
+            Contract.c.rent_amount,
+            Payer.c.name,
+            sqlalchemy.func.coalesce(sqlalchemy.func.sum(Payment.c.amount), 0).label("paid"),
+        )
+        .select_from(Contract)
+        .join(Payer, Payer.c.id == Contract.c.payer_id)
+        .outerjoin(
+            Payment,
+            (Payment.c.agreement_id == Contract.c.id)
+            & (sqlalchemy.extract('year', Payment.c.payment_date) == year),
+        )
+        .group_by(Contract.c.id, Payer.c.name)
+        .order_by(Payer.c.name)
+    )
+    total = 0.0
+    lines = [f"\U0001F4CA Звіт по виплатах за {year} рік:", ""]
+    for r in rows:
+        paid = float(r["paid"] or 0)
+        total += paid
+        rent = float(r["rent_amount"] or 0)
+        fio = short_fio(r["name"])
+        if paid >= rent:
+            lines.append(f"\U0001F464 {fio} — \U0001F4C4 №{r['number']} — ✅ {format_money(paid)}")
+        else:
+            debt = format_money(rent - paid)
+            lines.append(
+                f"\U0001F464 {fio} — \U0001F4C4 №{r['number']} — ❌ {format_money(paid)} (борг {debt})"
+            )
+    lines.append("")
+    lines.append(f"\U0001F4B0 Всього виплачено: {format_money(total)}")
+    lines.append(f"\U0001F4CC Договорів: {len(rows)}")
+    kb = [
+        [InlineKeyboardButton("\U0001F4E4 Завантажити звіт", callback_data=f"pay_csv:{year}")],
+        [InlineKeyboardButton("\U0001F501 Назад", callback_data="payment_reports")],
+    ]
+    await query.message.edit_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb))
+
+
+async def payment_report_csv_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    year = int(query.data.split(":")[1])
+    rows = await database.fetch_all(
+        sqlalchemy.select(
+            Contract.c.number,
+            Payer.c.name,
+            Contract.c.rent_amount,
+            sqlalchemy.func.coalesce(sqlalchemy.func.sum(Payment.c.amount), 0).label("paid"),
+        )
+        .select_from(Contract)
+        .join(Payer, Payer.c.id == Contract.c.payer_id)
+        .outerjoin(
+            Payment,
+            (Payment.c.agreement_id == Contract.c.id)
+            & (sqlalchemy.extract('year', Payment.c.payment_date) == year),
+        )
+        .group_by(Contract.c.id, Payer.c.name)
+        .order_by(Payer.c.name)
+    )
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Payer", "Contract", "Rent", "Paid", "Debt"])
+    for r in rows:
+        rent = float(r["rent_amount"] or 0)
+        paid = float(r["paid"] or 0)
+        writer.writerow([r["name"], r["number"], rent, paid, rent - paid])
+    output.seek(0)
+    bio = BytesIO(output.getvalue().encode("utf-8"))
+    await query.message.reply_document(
+        document=InputFile(bio, filename=f"payments_{year}.csv")
+    )
+
+
+global_add_payment_conv = ConversationHandler(
+    entry_points=[MessageHandler(filters.Regex("^➕ Додати виплату$"), global_add_payment_start)],
+    states={
+        SEARCH_PAYER: [MessageHandler(filters.TEXT & ~filters.COMMAND, global_add_payment_search)],
+    },
+    fallbacks=[CommandHandler("start", to_menu)],
 )

--- a/main.py
+++ b/main.py
@@ -40,7 +40,16 @@ from dialogs.contract import (
     payment_summary_cb,
     payment_history_cb,
 )
-from dialogs.payment import add_payment_conv
+from dialogs.payment import (
+    add_payment_conv,
+    global_add_payment_conv,
+    select_payer_cb,
+    select_contract_cb,
+    show_payments,
+    payment_reports_start,
+    payment_report_cb,
+    payment_report_csv_cb,
+)
 from dialogs.edit_field import edit_field_conv
 from dialogs.edit_land import edit_land_conv
 from dialogs.edit_land_owner import edit_land_owner_conv
@@ -106,6 +115,9 @@ application.add_handler(MessageHandler(filters.Regex("^📋 Список пай�
 application.add_handler(search_payer_conv)
 application.add_handler(search_land_conv)
 application.add_handler(edit_payer_conv)
+application.add_handler(global_add_payment_conv)
+application.add_handler(MessageHandler(filters.Regex("^📋 Перелік виплат$"), show_payments))
+application.add_handler(MessageHandler(filters.Regex("^💳 Звіти по виплатах$"), payment_reports_start))
 
 # --- ДІЛЯНКИ/ПОЛЯ ---
 application.add_handler(add_field_conv)
@@ -147,6 +159,10 @@ application.add_handler(CallbackQueryHandler(agreement_card, pattern=r"^(contrac
 application.add_handler(edit_contract_conv)
 application.add_handler(change_status_conv)
 application.add_handler(add_payment_conv)
+application.add_handler(CallbackQueryHandler(select_payer_cb, pattern=r"^pay_select:\d+$"))
+application.add_handler(CallbackQueryHandler(select_contract_cb, pattern=r"^pay_contract:\d+$"))
+application.add_handler(CallbackQueryHandler(payment_report_cb, pattern=r"^pay_report:\d+$"))
+application.add_handler(CallbackQueryHandler(payment_report_csv_cb, pattern=r"^pay_csv:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_summary_cb, pattern=r"^payment_summary:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_history_cb, pattern=r"^payment_history:\d+$"))
 application.add_handler(CallbackQueryHandler(generate_contract_pdf_cb, pattern=r"^generate_contract_pdf:\d+$"))


### PR DESCRIPTION
## Summary
- integrate payments search and reporting with main menu
- add global payer search and contract selection for payments
- show recent payments list
- implement yearly payment reports with CSV export
- wire new handlers into bot entrypoints

## Testing
- `python -m py_compile dialogs/payment.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ed9c1b648321ac2431dda93883e3