### PR TITLE
Fix add payment handling and message editing

### DIFF
--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -104,7 +104,7 @@ async def build_land_keyboard(context: ContextTypes.DEFAULT_TYPE) -> InlineKeybo
 async def show_land_options(msg_obj: Any, context: ContextTypes.DEFAULT_TYPE) -> int:
     markup = await build_land_keyboard(context)
     text = "Оберіть ділянки для договору:"
-    if hasattr(msg_obj, "edit_text"):
+    if getattr(getattr(msg_obj, "from_user", None), "is_bot", False):
         await msg_obj.edit_text(text, reply_markup=markup)
     else:
         await msg_obj.reply_text(text, reply_markup=markup)


### PR DESCRIPTION
## Summary
- ensure show_land_options only edits bot messages
- centralize starting add payment dialog to avoid mutating query data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887f693d908832198092b943442acd0