### PR TITLE
Implement admin-only agreement deletion

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,8 @@ from dialogs.contract import (
     contract_docs,
     delete_contract_prompt,
     delete_contract,
+    agreement_delete_prompt,
+    agreement_delete_confirm,
     generate_contract_pdf_cb,
     edit_contract_conv,
     change_status_conv,
@@ -169,6 +171,8 @@ application.add_handler(CallbackQueryHandler(generate_contract_pdf_cb, pattern=r
 application.add_handler(CallbackQueryHandler(contract_docs, pattern=r"^contract_docs:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_contract_prompt, pattern=r"^delete_contract:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_contract, pattern=r"^confirm_delete_contract:\d+$"))
+application.add_handler(CallbackQueryHandler(agreement_delete_prompt, pattern=r"^agreement_delete:\d+$"))
+application.add_handler(CallbackQueryHandler(agreement_delete_confirm, pattern=r"^agreement_delete_confirm$"))
 application.add_handler(CallbackQueryHandler(to_contracts, pattern=r"^to_contracts$"))
 application.add_handler(CallbackQueryHandler(send_contract_pdf, pattern=r"^view_pdf:contract:\d+:.+"))
 


### PR DESCRIPTION
## Summary
- add admin-only delete button to contract card
- implement delete confirmation flow with cleanup of payments and files
- register new handlers for agreement deletion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b8cd7721c8321b10a7886c0244b7f