### PR TITLE
Add CRM events on card pages

### DIFF
--- a/crm/events_integration.py
+++ b/crm/events_integration.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime
+import sqlalchemy
+
+from telegram import Update, InlineKeyboardButton
+from telegram.ext import (
+    ContextTypes,
+    CallbackQueryHandler,
+    MessageHandler,
+    ConversationHandler,
+    filters,
+)
+
+from db import database, CRMEvent
+from utils.fsm_navigation import (
+    back_cancel_keyboard,
+    push_state,
+    cancel_handler,
+    CANCEL_BTN,
+)
+from crm.events import (
+    DATE_INPUT,
+    TYPE_CHOOSE,
+    COMMENT_INPUT,
+    set_date,
+    type_cb,
+    save_comment,
+    show_menu,
+)
+
+STATUS_ICONS = {
+    "planned": "\u23F3",  # ⏳
+    "done": "\u2705",     # ✅
+    "canceled": "\u274C",  # ❌
+}
+
+
+async def get_events_text(entity_type: str, entity_id: int) -> str:
+    query = (
+        sqlalchemy.select(CRMEvent)
+        .where(
+            CRMEvent.c.entity_type == entity_type,
+            CRMEvent.c.entity_id == entity_id,
+        )
+        .order_by(CRMEvent.c.event_date.desc())
+        .limit(5)
+    )
+    rows = await database.fetch_all(query)
+    if not rows:
+        return "\U0001F4C5 \u041F\u043E\u0434\u0456\u0439 \u043D\u0435 \u0437\u0430\u043F\u043B\u0430\u043D\u043E\u0432\u0430\u043D\u043E."
+    lines = [
+        f"\u2022 {r['event_date'].strftime('%d.%m.%Y')} \u2014 {r['event_type']} \u2014 {STATUS_ICONS.get(r['status'], '')}"
+        for r in rows
+    ]
+    return "\U0001F4C5 \u041F\u043E\u0434\u0456\u0457:\n" + "\n".join(lines)
+
+
+def events_button(entity_type: str, entity_id: int) -> InlineKeyboardButton:
+    return InlineKeyboardButton(
+        "\u2795 \u0414\u043E\u0434\u0430\u0442\u0438 \u043F\u043E\u0434\u0456\u044E",
+        callback_data=f"add_event:{entity_type}:{entity_id}",
+    )
+
+
+async def add_event_from_card(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    _, entity_type, entity_id = query.data.split(":")
+
+    context.user_data.clear()
+    context.user_data["fsm_history"] = []
+    context.user_data["entity_type"] = entity_type
+    context.user_data["entity_id"] = int(entity_id)
+
+    push_state(context, DATE_INPUT)
+    await query.message.reply_text(
+        "\u0412\u0432\u0435\u0434\u0456\u0442\u044C \u0434\u0430\u0442\u0443 \u043F\u043E\u0434\u0456\u0457 (\u0414\u0414.\u041C.\u0420\u0420\u0420\u0420):",
+        reply_markup=back_cancel_keyboard,
+    )
+    return DATE_INPUT
+
+
+add_event_from_card_conv = ConversationHandler(
+    entry_points=[
+        CallbackQueryHandler(
+            add_event_from_card,
+            pattern=r"^add_event:(payer|contract|land|potential_payer):\d+$",
+        )
+    ],
+    states={
+        DATE_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, set_date)],
+        TYPE_CHOOSE: [CallbackQueryHandler(type_cb, pattern=r"^(etype:\d+|back)$")],
+        COMMENT_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, save_comment)],
+    },
+    fallbacks=[MessageHandler(filters.Regex(f"^{CANCEL_BTN}$"), cancel_handler(show_menu))],
+)

--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -589,6 +589,10 @@ async def agreement_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
         f"📥 Завантажені документи: {docs_count} файла(ів)"
     )
 
+    from crm.events_integration import get_events_text, events_button
+    events_block = await get_events_text("contract", contract_id)
+    text += "\n\n" + events_block
+
     # === Платежі ===
     payments = await database.fetch_all(
         sqlalchemy.select(Payment).where(Payment.c.agreement_id == contract_id).order_by(Payment.c.payment_date)
@@ -638,6 +642,7 @@ async def agreement_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton("📝 Редагувати", callback_data=f"edit_contract:{contract_id}")],
         [InlineKeyboardButton("📌 Змінити статус", callback_data=f"change_status:{contract_id}")],
         [InlineKeyboardButton("📁 Документи", callback_data=f"contract_docs:{contract_id}")],
+        [events_button("contract", contract_id)],
     ]
     from db import get_user_by_tg_id
     user = await get_user_by_tg_id(update.effective_user.id)

--- a/dialogs/land.py
+++ b/dialogs/land.py
@@ -336,6 +336,10 @@ async def land_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
         f"Власники: {owners_txt}"
     )
 
+    from crm.events_integration import get_events_text, events_button
+    events_block = await get_events_text("land", land_id)
+    text += "\n\n" + events_block
+
     buttons = []
     # --- Додати документи ---
     buttons.append([
@@ -363,6 +367,7 @@ async def land_card(update: Update, context: ContextTypes.DEFAULT_TYPE):
     buttons.extend([
         [InlineKeyboardButton("✏️ Редагувати", callback_data=f"edit_land:{land['id']}")],
         [InlineKeyboardButton("🗑 Видалити", callback_data=f"delete_land:{land['id']}")],
+        [events_button("land", land_id)],
         [InlineKeyboardButton("⬅️ До списку", callback_data="to_lands_list")]
     ])
 

--- a/dialogs/payer.py
+++ b/dialogs/payer.py
@@ -398,6 +398,10 @@ async def payer_card(update, context):
         f"🏠 Адреса: {payer.oblast} обл., {payer.rayon} р-н, с. {payer.selo}, вул. {payer.vul}, буд. {payer.bud}, кв. {payer.kv}"
     )
 
+    from crm.events_integration import get_events_text, events_button
+    events_block = await get_events_text("payer", payer.id)
+    text += "\n\n" + events_block
+
     keyboard = []
 
     # Визначаємо тип документу (entity_type) для пайовика: паспорт чи ID
@@ -427,6 +431,7 @@ async def payer_card(update, context):
         [InlineKeyboardButton("Редагувати", callback_data=f"edit_payer:{payer.id}")],
         [InlineKeyboardButton("Видалити", callback_data=f"delete_payer:{payer.id}")],
         [InlineKeyboardButton("Створити договір оренди", callback_data=f"create_contract:{payer.id}")],
+        [events_button("payer", payer.id)],
         [InlineKeyboardButton("До меню", callback_data="to_menu")]
     ])
 

--- a/dialogs/potential_payer.py
+++ b/dialogs/potential_payer.py
@@ -318,10 +318,16 @@ async def card_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
         f"📅 Останній контакт: {payer['last_contact_date'] or '-'}\n"
         f"📘 Статус: {payer['status']}"
     )
+
+    from crm.events_integration import get_events_text, events_button
+    events_block = await get_events_text("potential_payer", pp_id)
+    text += "\n\n" + events_block
+
     keyboard = InlineKeyboardMarkup([
         [InlineKeyboardButton("✏️ Змінити статус", callback_data=f"pp_chst:{pp_id}")],
         [InlineKeyboardButton("🔄 Перевести в активні", callback_data=f"pp_conv:{pp_id}")],
         [InlineKeyboardButton("🗑 Видалити", callback_data=f"pp_del:{pp_id}")],
+        [events_button("potential_payer", pp_id)],
         [InlineKeyboardButton("⬅️ Назад", callback_data="pp_list")],
     ])
     await query.message.edit_text(text, reply_markup=keyboard)
@@ -509,10 +515,16 @@ async def send_pp_card(msg, pp_id: int):
         f"📅 Останній контакт: {payer['last_contact_date'] or '-'}\n"
         f"📘 Статус: {payer['status']}"
     )
+
+    from crm.events_integration import get_events_text, events_button
+    events_block = await get_events_text("potential_payer", pp_id)
+    text += "\n\n" + events_block
+
     keyboard = InlineKeyboardMarkup([
         [InlineKeyboardButton("✏️ Змінити статус", callback_data=f"pp_chst:{pp_id}")],
         [InlineKeyboardButton("🔄 Перевести в активні", callback_data=f"pp_conv:{pp_id}")],
         [InlineKeyboardButton("🗑 Видалити", callback_data=f"pp_del:{pp_id}")],
+        [events_button("potential_payer", pp_id)],
         [InlineKeyboardButton("⬅️ Назад", callback_data="pp_list")],
     ])
     await msg.reply_text(text, reply_markup=keyboard)

--- a/main.py
+++ b/main.py
@@ -77,6 +77,7 @@ from dialogs.agreement_template import (
 )
 
 from crm.events import add_event_conv, list_events_conv
+from crm.events_integration import add_event_from_card_conv
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 WEBHOOK_PATH = "/webhook"
 WEBHOOK_URL = os.getenv("WEBHOOK_URL")
@@ -145,6 +146,7 @@ application.add_handler(add_field_conv)
 application.add_handler(MessageHandler(filters.Regex("^📋 Список полів$"), show_fields))
 # --- Планування та події ---
 application.add_handler(add_event_conv)
+application.add_handler(add_event_from_card_conv)
 application.add_handler(list_events_conv)
 
 application.add_handler(add_land_conv)


### PR DESCRIPTION
## Summary
- integrate CRM events in payer, contract, land and potential payer cards
- allow quick event creation from cards
- register new handler for quick event creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bcbceea6883219c61269e7bb6301e