### PR TITLE
Add responsible user selection for CRM events

### DIFF
--- a/crm/event_reminders.py
+++ b/crm/event_reminders.py
@@ -63,7 +63,7 @@ async def check_daily(app: Application):
             continue
         text = await _format_reminder(r, "\u23F0 \u041F\u043E\u0434\u0456\u044F \u0441\u044C\u043E\u0433\u043E\u0434\u043D\u0456:")
         recipients = set(admin_ids)
-        recipients.add(r["created_by_user_id"])
+        recipients.add(r["responsible_user_id"])
         await _send_to(recipients, text, app)
         await _update_status(r["id"], "daily", status)
 
@@ -88,7 +88,7 @@ async def check_one_hour(app: Application):
             continue
         text = await _format_reminder(r, "\u23F0 \u041F\u043E\u0434\u0456\u044F \u0437\u0430 \u0433\u043E\u0434\u0438\u043D\u0443:")
         recipients = set(admin_ids)
-        recipients.add(r["created_by_user_id"])
+        recipients.add(r["responsible_user_id"])
         await _send_to(recipients, text, app)
         await _update_status(r["id"], "1h", status)
 
@@ -113,7 +113,7 @@ async def check_now(app: Application):
             continue
         text = await _format_reminder(r, "\u23F0 \u041F\u043E\u0434\u0456\u044F \u0437\u0430\u0440\u0430\u0437:")
         recipients = set(admin_ids)
-        recipients.add(r["created_by_user_id"])
+        recipients.add(r["responsible_user_id"])
         await _send_to(recipients, text, app)
         await _update_status(r["id"], "now", status)
 

--- a/crm/events_integration.py
+++ b/crm/events_integration.py
@@ -23,9 +23,13 @@ from crm.events import (
     DATE_INPUT,
     TYPE_CHOOSE,
     COMMENT_INPUT,
+    RESPONSIBLE_CHOOSE,
+    RESPONSIBLE_ID,
     set_date,
     type_cb,
     save_comment,
+    responsible_cb,
+    responsible_id_input,
     show_menu,
 )
 
@@ -92,6 +96,8 @@ add_event_from_card_conv = ConversationHandler(
         DATE_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, set_date)],
         TYPE_CHOOSE: [CallbackQueryHandler(type_cb, pattern=r"^(etype:\d+|back)$")],
         COMMENT_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, save_comment)],
+        RESPONSIBLE_CHOOSE: [CallbackQueryHandler(responsible_cb, pattern=r"^(resp:(self|other)|user:\d+|manual|back)$")],
+        RESPONSIBLE_ID: [MessageHandler(filters.TEXT & ~filters.COMMAND, responsible_id_input)],
     },
     fallbacks=[MessageHandler(filters.Regex(f"^{CANCEL_BTN}$"), cancel_handler(show_menu))],
 )

--- a/db.py
+++ b/db.py
@@ -251,6 +251,7 @@ CRMEvent = sqlalchemy.Table(
     sqlalchemy.Column("event_datetime", sqlalchemy.DateTime),
     sqlalchemy.Column("event_type", sqlalchemy.String),
     sqlalchemy.Column("comment", sqlalchemy.String),
+    sqlalchemy.Column("responsible_user_id", sqlalchemy.BigInteger, nullable=False),
     sqlalchemy.Column("status", sqlalchemy.String, default="planned"),
     sqlalchemy.Column("created_at", sqlalchemy.DateTime, default=datetime.utcnow),
     sqlalchemy.Column("created_by_user_id", sqlalchemy.BigInteger),
@@ -394,5 +395,8 @@ with engine.begin() as conn:
     ))
     conn.execute(sqlalchemy.text(
         "ALTER TABLE \"crm_events\" ADD COLUMN IF NOT EXISTS reminder_status JSONB DEFAULT '{}'::jsonb"
+    ))
+    conn.execute(sqlalchemy.text(
+        'ALTER TABLE "crm_events" ADD COLUMN IF NOT EXISTS responsible_user_id BIGINT NOT NULL DEFAULT 0'
     ))
 


### PR DESCRIPTION
## Summary
- add `responsible_user_id` column
- extend FSM for events to assign responsible users
- update reminders to use responsible user
- show responsible user in event text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688be89c09648321a0611d42708e2f9f