### PR TITLE
Fix CRM events FSM navigation

### DIFF
--- a/crm/event_fsm_navigation.py
+++ b/crm/event_fsm_navigation.py
@@ -38,7 +38,9 @@ def cancel_handler(menu_function=show_crm_menu):
             reply_markup=ReplyKeyboardRemove(),
         )
         context.user_data.clear()
-        return await menu_function(update, context)
+        if menu_function:
+            await menu_function(update, context)
+        return ConversationHandler.END
 
     return _cancel
 
@@ -53,7 +55,7 @@ async def handle_back_cancel(update, context: ContextTypes.DEFAULT_TYPE, menu_fu
         )
         context.user_data.clear()
         if menu_function:
-            return await menu_function(update, context)
+            await menu_function(update, context)
         return ConversationHandler.END
     if text == BACK_BTN:
         prev_state = pop_state(context)
@@ -64,7 +66,7 @@ async def handle_back_cancel(update, context: ContextTypes.DEFAULT_TYPE, menu_fu
             )
             context.user_data.clear()
             if menu_function:
-                return await menu_function(update, context)
+                await menu_function(update, context)
             return ConversationHandler.END
         return prev_state
     return None

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -121,6 +121,7 @@ crm_potential_menu = ReplyKeyboardMarkup(
 crm_events_menu = ReplyKeyboardMarkup([
     ["➕ Додати подію"],
     ["📋 Переглянути події"],
+    ["📅 Події за датою"],
     ["◀️ Назад"],
 ], resize_keyboard=True)
 

--- a/main.py
+++ b/main.py
@@ -77,6 +77,7 @@ from dialogs.agreement_template import (
 )
 
 from crm.events import add_event_conv, list_events_conv
+from crm.events_view_pagination import view_events_conv
 from crm.events_integration import add_event_from_card_conv
 from crm.event_reminders import start_reminder_tasks, stop_reminder_tasks
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -151,6 +152,7 @@ application.add_handler(MessageHandler(filters.Regex("^📋 Список пол�
 application.add_handler(add_event_conv)
 application.add_handler(add_event_from_card_conv)
 application.add_handler(list_events_conv)
+application.add_handler(view_events_conv)
 
 application.add_handler(add_land_conv)
 application.add_handler(MessageHandler(filters.Regex("^📋 Список ділянок$"), show_lands))

--- a/utils/fsm_navigation.py
+++ b/utils/fsm_navigation.py
@@ -28,11 +28,13 @@ def cancel_handler(menu_function):
 
     async def _cancel(update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(
-            "❌ Додавання скасовано. Дані не збережено.",
+            "❌ Додавання події скасовано. Ви повернулись до CRM.",
             reply_markup=ReplyKeyboardRemove(),
         )
         context.user_data.clear()
-        return await menu_function(update, context)
+        if menu_function:
+            await menu_function(update, context)
+        return ConversationHandler.END
 
     return _cancel
 
@@ -42,23 +44,23 @@ async def handle_back_cancel(update, context: ContextTypes.DEFAULT_TYPE, menu_fu
     text = update.message.text if update.message else None
     if text == CANCEL_BTN:
         await update.message.reply_text(
-            "❌ Додавання скасовано. Дані не збережено.",
+            "❌ Додавання події скасовано. Ви повернулись до CRM.",
             reply_markup=ReplyKeyboardRemove(),
         )
         context.user_data.clear()
         if menu_function:
-            return await menu_function(update, context)
+            await menu_function(update, context)
         return ConversationHandler.END
     if text == BACK_BTN:
         prev_state = pop_state(context)
         if prev_state is None:
             await update.message.reply_text(
-                "❌ Додавання скасовано. Дані не збережено.",
+                "❌ Додавання події скасовано. Ви повернулись до CRM.",
                 reply_markup=ReplyKeyboardRemove(),
             )
             context.user_data.clear()
             if menu_function:
-                return await menu_function(update, context)
+                await menu_function(update, context)
             return ConversationHandler.END
         return prev_state
     return None


### PR DESCRIPTION
## Summary
- fix cancel-handler to properly end conversations
- tweak back button behavior in CRM event FSM
- integrate date-based event view via dedicated menu button

## Testing
- `python -m py_compile keyboards/menu.py crm/event_fsm_navigation.py utils/fsm_navigation.py crm/events.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688c59012e448321905c09038e6d76b6