### PR TITLE
Fix circular import by extracting format_event

### DIFF
--- a/crm/event_utils.py
+++ b/crm/event_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sqlalchemy
+from db import database, Payer, PotentialPayer, Contract, LandPlot, User
+
+async def format_event(row) -> str:
+    """Return formatted event representation for display."""
+    if row["entity_type"] == "payer":
+        p = await database.fetch_one(sqlalchemy.select(Payer).where(Payer.c.id == row["entity_id"]))
+        entity = f"\U0001F464 {p['name']} (поточний)" if p else f"ID {row['entity_id']}"
+    elif row["entity_type"] == "potential_payer":
+        p = await database.fetch_one(sqlalchemy.select(PotentialPayer).where(PotentialPayer.c.id == row["entity_id"]))
+        entity = f"\U0001F464 {p['full_name']} (потенційний)" if p else f"ID {row['entity_id']}"
+    elif row["entity_type"] == "contract":
+        c = await database.fetch_one(sqlalchemy.select(Contract).where(Contract.c.id == row["entity_id"]))
+        entity = f"\U0001F4DC Договір №{c['number']}" if c else f"ID {row['entity_id']}"
+    else:
+        land = await database.fetch_one(sqlalchemy.select(LandPlot).where(LandPlot.c.id == row["entity_id"]))
+        entity = f"\U0001F4CD {land['cadaster']}" if land else f"ID {row['entity_id']}"
+    d = row["event_datetime"].strftime("%d.%m.%Y %H:%M")
+    user = await database.fetch_one(sqlalchemy.select(User).where(User.c.telegram_id == row["responsible_user_id"]))
+    resp = user["full_name"] if user else f"ID {row['responsible_user_id']}"
+    txt = (
+        f"\U0001F4C5 {d} — {row['event_type']}\n"
+        f"{entity}\n"
+        f"\U0001F9D1\u200D\U0001F4BC Відповідальний: {resp}\n"
+        f"\U0001F4DD {row['comment'] or '-'}"
+    )
+    return txt

--- a/crm/events.py
+++ b/crm/events.py
@@ -16,6 +16,8 @@ from telegram.ext import (
 )
 import sqlalchemy
 
+from crm.event_utils import format_event
+
 from db import (
     database,
     CRMEvent,
@@ -588,30 +590,6 @@ async def filter_id_input(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
     await _show_rows(update.message, rows)
     return ConversationHandler.END
-
-async def format_event(row) -> str:
-    if row["entity_type"] == "payer":
-        p = await database.fetch_one(sqlalchemy.select(Payer).where(Payer.c.id == row["entity_id"]))
-        entity = f"\U0001F464 {p['name']} (поточний)" if p else f"ID {row['entity_id']}"
-    elif row["entity_type"] == "potential_payer":
-        p = await database.fetch_one(sqlalchemy.select(PotentialPayer).where(PotentialPayer.c.id == row["entity_id"]))
-        entity = f"\U0001F464 {p['full_name']} (потенційний)" if p else f"ID {row['entity_id']}"
-    elif row["entity_type"] == "contract":
-        c = await database.fetch_one(sqlalchemy.select(Contract).where(Contract.c.id == row["entity_id"]))
-        entity = f"\U0001F4DC Договір №{c['number']}" if c else f"ID {row['entity_id']}"
-    else:
-        land = await database.fetch_one(sqlalchemy.select(LandPlot).where(LandPlot.c.id == row["entity_id"]))
-        entity = f"\U0001F4CD {land['cadaster']}" if land else f"ID {row['entity_id']}"
-    d = row["event_datetime"].strftime("%d.%m.%Y %H:%M")
-    user = await database.fetch_one(sqlalchemy.select(User).where(User.c.telegram_id == row["responsible_user_id"]))
-    resp = user["full_name"] if user else f"ID {row['responsible_user_id']}"
-    txt = (
-        f"\U0001F4C5 {d} — {row['event_type']}\n"
-        f"{entity}\n"
-        f"\U0001F9D1\u200D\U0001F4BC Відповідальний: {resp}\n"
-        f"\U0001F4DD {row['comment'] or '-'}"
-    )
-    return txt
 
 list_events_conv = ConversationHandler(
     entry_points=[MessageHandler(filters.Regex("^📋 Переглянути події$"), list_start)],

--- a/crm/events_filter_by_date.py
+++ b/crm/events_filter_by_date.py
@@ -27,7 +27,7 @@ from crm.event_fsm_navigation import (
     cancel_handler,
     show_crm_menu,
 )
-from crm.events import format_event
+from crm.event_utils import format_event
 
 
 # conversation states for date filtering

--- a/crm/events_view_pagination.py
+++ b/crm/events_view_pagination.py
@@ -21,7 +21,7 @@ from crm.event_fsm_navigation import (
     cancel_handler,
     show_crm_menu,
 )
-from crm.events import format_event
+from crm.event_utils import format_event
 
 # conversation states
 MODE_CHOOSE, SHOW_PAGE, SHOW_CARD = range(3)


### PR DESCRIPTION
## Summary
- create `crm/event_utils.py` to hold `format_event`
- use `format_event` from new module in events modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c62b84bd88321ae9655d04534f661