### PR TITLE
Fix unknown state warning in CRM event filter

### DIFF
--- a/crm/events_filter_by_date.py
+++ b/crm/events_filter_by_date.py
@@ -31,7 +31,9 @@ from crm.event_utils import format_event
 
 
 # conversation states for date filtering
-FILTER_DATE_MODE, FILTER_DATES_LIST, FILTER_ALL_EVENTS = range(3)
+# These values must match the states defined in ``crm.events`` since
+# ``events.py`` delegates part of its conversation flow to this module.
+FILTER_DATE_MODE, FILTER_DATES_LIST, FILTER_ALL_EVENTS = range(101, 104)
 PAGE_SIZE = 5
 
 


### PR DESCRIPTION
## Summary
- align CRM date filter conversation state numbers with those defined in `events.py`

## Testing
- `python -m py_compile crm/events_filter_by_date.py crm/events.py`

------
https://chatgpt.com/codex/tasks/task_e_688c826d77508321b003a7e19fe3d500