### PR TITLE
Fix events view cancellation

### DIFF
--- a/crm/events_view_pagination.py
+++ b/crm/events_view_pagination.py
@@ -262,7 +262,11 @@ async def cancel_event_filter(update: Update, context: ContextTypes.DEFAULT_TYPE
     """Cancel viewing events after empty result."""
     query = update.callback_query
     await query.answer()
-    await query.message.edit_text("❌ Перегляд подій завершено.")
+    context.user_data.clear()
+    await query.edit_message_text(
+        "❌ Перегляд подій завершено.",
+        reply_markup=None,
+    )
     return ConversationHandler.END
 
 


### PR DESCRIPTION
## Summary
- clear `user_data` and remove inline keyboard when cancelling event view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c883e78988321b96dd2b10f7a35f8