### PR TITLE
Fix cancel event pagination handler

### DIFF
--- a/crm/events_view_pagination.py
+++ b/crm/events_view_pagination.py
@@ -259,14 +259,19 @@ async def retry_event_filter(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 
 async def cancel_event_filter(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    """Cancel viewing events after empty result."""
-    query = update.callback_query
-    await query.answer()
+    """Fully terminate the FSM when cancelling event viewing."""
     context.user_data.clear()
-    await query.edit_message_text(
-        "❌ Перегляд подій завершено.",
-        reply_markup=None,
-    )
+
+    if update.callback_query:
+        query = update.callback_query
+        await query.answer()
+        await query.edit_message_text(
+            "❌ Перегляд подій завершено.",
+            reply_markup=None,  # обовʼязкове очищення кнопок
+        )
+    else:
+        await update.message.reply_text("❌ Перегляд подій завершено.")
+
     return ConversationHandler.END
 
 


### PR DESCRIPTION
## Summary
- ensure `cancel_event_filter` fully ends the FSM for both text and callback invocations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c8b08401883219c28d0a4042adbd9