### PR TITLE
Fix doc prompt message with callbacks and owner cleanup

### DIFF
--- a/dialogs/land.py
+++ b/dialogs/land.py
@@ -454,6 +454,12 @@ async def delete_land(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await database.execute(
             UploadedDocs.delete().where(UploadedDocs.c.id.in_([d["id"] for d in docs]))
         )
+
+    # Remove owners linked to the land plot before deleting the plot itself
+    await database.execute(
+        LandPlotOwner.delete().where(LandPlotOwner.c.land_plot_id == land_id)
+    )
+
     await database.execute(LandPlot.delete().where(LandPlot.c.id == land_id))
     linked = f"docs:{len(docs)}" if docs else ""
     await log_delete(update.effective_user.id, user["role"], "land", land_id, land.cadaster, linked)

--- a/dialogs/post_creation.py
+++ b/dialogs/post_creation.py
@@ -15,7 +15,9 @@ async def prompt_add_docs(
     context.user_data["post_create_msg"] = final_text
     context.user_data["post_create_markup"] = final_markup
 
-    await update.message.reply_text(
+    msg = update.message or update.callback_query.message
+
+    await msg.reply_text(
         "✅ Об’єкт створено.\n📎 Бажаєте одразу додати документи?",
         reply_markup=InlineKeyboardMarkup(
             [


### PR DESCRIPTION
## Summary
- send document prompt to callback messages
- ensure land owners are removed when deleting land

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d1cb9ef9083218da46503255f7bb6