### PR TITLE
Improve contract list display

### DIFF
--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -47,6 +47,7 @@ from contract_generation_v2 import (
 )
 from template_utils import analyze_template, build_unresolved_message
 import sqlalchemy
+from utils.names import short_name
 
 logger = logging.getLogger(__name__)
 
@@ -538,17 +539,20 @@ async def show_contracts(update: Update, context: ContextTypes.DEFAULT_TYPE):
     for r in rows:
         cname = r["short_name"] or r["full_name"] or "—"
         payers = [p for p in (r["payer_names"] or []) if p]
-        if not payers:
+        payer_names = [short_name(p) for p in payers]
+        if not payer_names:
             payer_line = "👤 Пайовик: —"
-        elif len(payers) == 1:
-            payer_line = f"👤 Пайовик: {html.escape(payers[0])}"
+        elif len(payer_names) == 1:
+            payer_line = f"👤 Пайовик: {html.escape(payer_names[0])}"
         else:
-            payer_line = f"👤 Пайовик: {html.escape(payers[0])} +{len(payers) - 1} ще"
+            shown = ", ".join(html.escape(n) for n in payer_names[:2])
+            if len(payer_names) > 2:
+                shown += f" +{len(payer_names) - 2} ще..."
+            payer_line = f"🧑‍🤝‍🧑 Пайовики: {shown}"
         btn = InlineKeyboardButton("Картка", callback_data=f"agreement_card:{r['id']}")
         number_part = html.escape(r["number"])
-        year_part = f"/{int(r['year'])}" if r["year"] else ""
         text = (
-            f"📄 Договір №{number_part}{year_part}\n"
+            f"📄 Договір №{number_part}\n"
             f"{payer_line}\n"
             f"🏢 Орендар: {html.escape(cname)}"
         )

--- a/utils/names.py
+++ b/utils/names.py
@@ -1,0 +1,13 @@
+def short_name(full_name: str) -> str:
+    """Return abbreviated version of Ukrainian full name.
+
+    Expected input: "Surname Name Patronymic" or "Surname Name".
+    Output example: "Іван І." for "Іванов Іван".
+    If the name doesn't contain at least two parts, return it unchanged.
+    """
+    parts = full_name.split()
+    if len(parts) >= 2:
+        first_name = parts[1]
+        surname_initial = parts[0][0].upper() + "."
+        return f"{first_name} {surname_initial}"
+    return full_name


### PR DESCRIPTION
## Summary
- abbreviate payer names and show first two with overflow indicator
- remove duplicated year from contract number display
- add utility to format short names

## Testing
- `python -m pytest`
- `python -m py_compile dialogs/contract.py utils/names.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc5919fb88321b8233d28bd2d914c