### PR TITLE
feat: show payers on contract list

### DIFF
--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -47,7 +47,7 @@ from contract_generation_v2 import (
 )
 from template_utils import analyze_template, build_unresolved_message
 import sqlalchemy
-from utils.names import short_name
+from utils.names import format_payers_line
 
 logger = logging.getLogger(__name__)
 
@@ -539,16 +539,7 @@ async def show_contracts(update: Update, context: ContextTypes.DEFAULT_TYPE):
     for r in rows:
         cname = r["short_name"] or r["full_name"] or "—"
         payers = [p for p in (r["payer_names"] or []) if p]
-        payer_names = [short_name(p) for p in payers]
-        if not payer_names:
-            payer_line = "👤 Пайовик: —"
-        elif len(payer_names) == 1:
-            payer_line = f"👤 Пайовик: {html.escape(payer_names[0])}"
-        else:
-            shown = ", ".join(html.escape(n) for n in payer_names[:2])
-            if len(payer_names) > 2:
-                shown += f" +{len(payer_names) - 2} ще..."
-            payer_line = f"🧑‍🤝‍🧑 Пайовики: {shown}"
+        payer_line = format_payers_line(payers)
         btn = InlineKeyboardButton("Картка", callback_data=f"agreement_card:{r['id']}")
         number_part = html.escape(r["number"])
         text = (

--- a/utils/names.py
+++ b/utils/names.py
@@ -11,3 +11,23 @@ def short_name(full_name: str) -> str:
         surname_initial = parts[0][0].upper() + "."
         return f"{first_name} {surname_initial}"
     return full_name
+
+
+def format_payers_line(payers: list[str]) -> str:
+    """Return formatted line with payer names for contract lists.
+
+    Uses :func:`short_name` to abbreviate each payer and applies the
+    "Pайовик"/"Пайовики" prefix depending on the number of participants.
+    The result matches the formatting used in contract cards.
+    """
+    import html
+
+    names = [short_name(p) for p in payers if p]
+    if not names:
+        return "👤 Пайовик: —"
+    if len(names) == 1:
+        return f"👤 Пайовик: {html.escape(names[0])}"
+    shown = ", ".join(html.escape(n) for n in names[:2])
+    if len(names) > 2:
+        shown += f" +{len(names) - 2} ще..."
+    return f"🧑‍🤝‍🧑 Пайовики: {shown}"


### PR DESCRIPTION
## Summary
- format payer names for contract list with helper
- join payer contracts to display payer info on contracts list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dc841bd0483218376dc60a43760e0