### PR TITLE
Display full payer name (ПІБ) in correct order in contract list

### DIFF
--- a/utils/names.py
+++ b/utils/names.py
@@ -16,18 +16,16 @@ def short_name(full_name: str) -> str:
 def format_payers_line(payers: list[str]) -> str:
     """Return formatted line with payer names for contract lists.
 
-    Uses :func:`short_name` to abbreviate each payer and applies the
-    "Pайовик"/"Пайовики" prefix depending on the number of participants.
-    The result matches the formatting used in contract cards.
+    Displays full names in the "Прізвище Імʼя По батькові" order. If several
+    payers are linked to the contract, their names are separated by commas.
+    When no payer information is available, a dash is shown instead.
     """
     import html
 
-    names = [short_name(p) for p in payers if p]
+    names = [p.strip() for p in payers if p]
     if not names:
-        return "👤 Пайовик: —"
+        return "🧑‍💼 Пайовик: —"
     if len(names) == 1:
-        return f"👤 Пайовик: {html.escape(names[0])}"
-    shown = ", ".join(html.escape(n) for n in names[:2])
-    if len(names) > 2:
-        shown += f" +{len(names) - 2} ще..."
+        return f"🧑‍💼 Пайовик: {html.escape(names[0])}"
+    shown = ", ".join(html.escape(n) for n in names)
     return f"🧑‍🤝‍🧑 Пайовики: {shown}"


### PR DESCRIPTION
## Summary
- show full payer names in contract list using surname-first ordering
- list multiple payers separated by commas and show dash when absent

## Testing
- `python -m py_compile utils/names.py dialogs/contract.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dcfc095148321a893165325d1b660