### PR TITLE
feat: handle deceased payers

### DIFF
--- a/crm/payer_request.py
+++ b/crm/payer_request.py
@@ -78,7 +78,12 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         sqlalchemy.select(Payer).order_by(Payer.c.id.desc()).limit(3)
     )
     keyboard = [
-        [InlineKeyboardButton(f"{p['id']}: {p['name']}", callback_data=f"payer:{p['id']}")]
+        [
+            InlineKeyboardButton(
+                f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}",
+                callback_data=f"payer:{p['id']}"
+            )
+        ]
         for p in recent
     ]
     keyboard.append([InlineKeyboardButton("🔍 Пошук пайовика", callback_data="search")])
@@ -114,7 +119,12 @@ async def search_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         await update.message.reply_text("Не знайдено. Спробуйте ще:")
         return SEARCH_INPUT
     keyboard = [
-        [InlineKeyboardButton(f"{r['name']} (ID:{r['id']})", callback_data=f"payer:{r['id']}")]
+        [
+            InlineKeyboardButton(
+                f"{ '⚰️ ' if r['is_deceased'] else ''}{r['name']} (ID:{r['id']})",
+                callback_data=f"payer:{r['id']}"
+            )
+        ]
         for r in rows
     ]
     keyboard.append([InlineKeyboardButton(BACK_BTN, callback_data="back")])

--- a/db.py
+++ b/db.py
@@ -34,6 +34,7 @@ Payer = sqlalchemy.Table(
     sqlalchemy.Column("idcard_issuer", sqlalchemy.String),
     sqlalchemy.Column("idcard_date", sqlalchemy.String),
     sqlalchemy.Column("birth_date", sqlalchemy.String),
+    sqlalchemy.Column("is_deceased", sqlalchemy.Boolean, default=False),
 )
 
 # === Таблиця Поле ===
@@ -392,6 +393,9 @@ with engine.begin() as conn:
     ))
     conn.execute(sqlalchemy.text(
         'ALTER TABLE "payer" ADD COLUMN IF NOT EXISTS bank_card VARCHAR'
+    ))
+    conn.execute(sqlalchemy.text(
+        'ALTER TABLE "payer" ADD COLUMN IF NOT EXISTS is_deceased BOOLEAN DEFAULT FALSE'
     ))
     conn.execute(sqlalchemy.text(
         'ALTER TABLE "contract" ADD COLUMN IF NOT EXISTS rent_amount NUMERIC(12,2)'

--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -393,12 +393,12 @@ async def set_valid_from(update: Update, context: ContextTypes.DEFAULT_TYPE):
         sqlalchemy.select(Payer).order_by(Payer.c.id.desc()).limit(3)
     )
     kb = ReplyKeyboardMarkup(
-        [[f"{p['id']}: {p['name']}"] for p in payers]
+        [[f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}"] for p in payers]
         + [["🔍 Пошук пайовика"], ["➕ Створити пайовика"], [BACK_BTN, CANCEL_BTN]],
         resize_keyboard=True,
     )
     context.user_data["recent_payers"] = {
-        f"{p['id']}: {p['name']}": p["id"] for p in payers
+        f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
     }
     await update.message.reply_text("Оберіть пайовика:", reply_markup=kb)
     await update.message.reply_text("⬇️ Навігація", reply_markup=back_cancel_kb)
@@ -414,6 +414,14 @@ async def choose_payer(update: Update, context: ContextTypes.DEFAULT_TYPE):
     text = update.message.text
     payer_id = context.user_data.get("recent_payers", {}).get(text)
     if payer_id:
+        row = await database.fetch_one(
+            sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+        )
+        if row and row["is_deceased"]:
+            await update.message.reply_text(
+                "❌ Неможливо додати договір чи виплату. Пайовик позначений як померлий."
+            )
+            return CHOOSE_PAYER
         context.user_data["payer_id"] = payer_id
     elif text in ("🔍 Пошук пайовика", "➕ Створити пайовика"):
         await update.message.reply_text("🔜 Функція в розробці")

--- a/dialogs/edit_payer.py
+++ b/dialogs/edit_payer.py
@@ -1,5 +1,13 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import ConversationHandler, MessageHandler, CallbackQueryHandler, CommandHandler, filters, ContextTypes
+from telegram.ext import (
+    ConversationHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    CommandHandler,
+    filters,
+    ContextTypes,
+)
+import sqlalchemy
 from db import database, Payer
 from dialogs.payer import normalize_bank_card
 
@@ -32,12 +40,22 @@ async def edit_payer_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
     payer_id = int(query.data.split(":")[1])
     context.user_data["edit_payer_id"] = payer_id
+    row = await database.fetch_one(
+        sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+    )
+    status_btn = (
+        "↩️ Зняти статус 'Помер'" if row and row["is_deceased"] else "⚰️ Позначити як померлого"
+    )
     keyboard = [
+        [InlineKeyboardButton(status_btn, callback_data=f"toggle_deceased:{payer_id}")]
+    ] + [
         [InlineKeyboardButton(field_name, callback_data=f"edit_field:{payer_id}:{field_key}")]
         for field_key, field_name in FIELDS
     ]
     keyboard.append([InlineKeyboardButton("Назад", callback_data=f"payer_card:{payer_id}")])
-    await query.message.edit_text("Оберіть поле для редагування:", reply_markup=InlineKeyboardMarkup(keyboard))
+    await query.message.edit_text(
+        "Оберіть поле для редагування:", reply_markup=InlineKeyboardMarkup(keyboard)
+    )
     return EDIT_SELECT
 
 async def edit_field_input(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -77,11 +95,28 @@ async def edit_field_save(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # return await edit_payer_menu_from_save(update, context)
     return ConversationHandler.END
 
+
+async def toggle_deceased(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    payer_id = int(query.data.split(":")[1])
+    row = await database.fetch_one(
+        sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+    )
+    new_val = not bool(row["is_deceased"]) if row is not None else True
+    await database.execute(
+        Payer.update().where(Payer.c.id == payer_id).values(is_deceased=new_val)
+    )
+    await query.answer("Статус оновлено")
+    # Show updated menu
+    query.data = f"edit_payer:{payer_id}"
+    return await edit_payer_menu(update, context)
+
 edit_payer_conv = ConversationHandler(
     entry_points=[CallbackQueryHandler(edit_payer_menu, pattern=r"^edit_payer:\d+$")],
     states={
         EDIT_SELECT: [
             CallbackQueryHandler(edit_field_input, pattern=r"^edit_field:\d+:\w+$"),
+            CallbackQueryHandler(toggle_deceased, pattern=r"^toggle_deceased:\d+$"),
             CallbackQueryHandler(edit_payer_menu, pattern=r"^edit_payer:\d+$"),
         ],
         EDIT_VALUE: [

--- a/dialogs/land.py
+++ b/dialogs/land.py
@@ -171,9 +171,12 @@ async def set_owner_count(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Спочатку додайте хоча б одного пайовика!", reply_markup=lands_menu)
         return ConversationHandler.END
     kb = ReplyKeyboardMarkup(
-        [[f"{p['id']}: {p['name']}"] for p in payers] + [["🔍 Пошук за ПІБ"]], resize_keyboard=True
+        [[f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}"] for p in payers] + [["🔍 Пошук за ПІБ"]],
+        resize_keyboard=True,
     )
-    context.user_data["payers"] = {f"{p['id']}: {p['name']}": p["id"] for p in payers}
+    context.user_data["payers"] = {
+        f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
+    }
     await update.message.reply_text(
         f"Оберіть власника 1 з {count}:", reply_markup=kb
     )
@@ -205,10 +208,12 @@ async def search_owner(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Нічого не знайдено. Спробуйте ще:")
         return SEARCH_OWNER
     kb = ReplyKeyboardMarkup(
-        [[f"{r['id']}: {r['name']}"] for r in rows] + [["◀️ Назад"]],
+        [[f"{r['id']}: {'⚰️ ' if r['is_deceased'] else ''}{r['name']}"] for r in rows] + [["◀️ Назад"]],
         resize_keyboard=True,
     )
-    context.user_data["search_results"] = {f"{r['id']}: {r['name']}": r["id"] for r in rows}
+    context.user_data["search_results"] = {
+        f"{r['id']}: {'⚰️ ' if r['is_deceased'] else ''}{r['name']}": r["id"] for r in rows
+    }
     await update.message.reply_text("Оберіть пайовика:", reply_markup=kb)
     return CHOOSE_OWNER
 

--- a/dialogs/payer.py
+++ b/dialogs/payer.py
@@ -536,9 +536,10 @@ async def show_payers(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Список порожній!")
         return
     for p in payers:
-        button = InlineKeyboardButton(f"Картка", callback_data=f"payer_card:{p.id}")
+        status = " ⚰️" if getattr(p, "is_deceased", False) else ""
+        button = InlineKeyboardButton("Картка", callback_data=f"payer_card:{p.id}")
         await update.message.reply_text(
-            f"{p.id}. {p.name} (ІПН: {p.ipn})",
+            f"{p.id}. {p.name}{status} (ІПН: {p.ipn})",
             reply_markup=InlineKeyboardMarkup([[button]])
         )
 
@@ -557,8 +558,9 @@ async def payer_card(update, context):
         await query.answer("Пайовик не знайдений!")
         return ConversationHandler.END
 
+    deceased_note = " <i>Помер</i>" if payer["is_deceased"] else ""
     text = (
-        f"<b>{payer.name}</b>\n"
+        f"<b>{payer.name}</b>{deceased_note}\n"
         f"🆔 ID: {payer.id}\n"
         f"📇 ІПН: {payer.ipn}\n"
         f"🎂 Дата народження: {payer.birth_date}\n"
@@ -698,8 +700,19 @@ async def delete_payer(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def create_contract(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
     payer_id = int(query.data.split(":")[1])
+    payer = await database.fetch_one(
+        sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+    )
+    if payer and payer["is_deceased"]:
+        await query.answer()
+        await query.message.reply_text(
+            "❌ Неможливо додати договір чи виплату. Пайовик позначений як померлий."
+        )
+        return
     await query.answer()
-    await query.message.reply_text(f"🔜 Функція створення договору в розробці!\nПайовик #{payer_id}")
+    await query.message.reply_text(
+        f"🔜 Функція створення договору в розробці!\nПайовик #{payer_id}"
+    )
 
 async def to_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query

--- a/dialogs/search.py
+++ b/dialogs/search.py
@@ -68,9 +68,10 @@ async def payer_search_do(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Пайовика не знайдено.")
         return ConversationHandler.END
     for p in results:
-        btn = InlineKeyboardButton(f"Картка", callback_data=f"payer_card:{p.id}")
+        status = " ⚰️" if getattr(p, "is_deceased", False) else ""
+        btn = InlineKeyboardButton("Картка", callback_data=f"payer_card:{p.id}")
         await update.message.reply_text(
-            f"{p.id}. {p.name} (ІПН: {p.ipn})",
+            f"{p.id}. {p.name}{status} (ІПН: {p.ipn})",
             reply_markup=InlineKeyboardMarkup([[btn]])
         )
     return ConversationHandler.END


### PR DESCRIPTION
## Summary
- track deceased payers with a new `is_deceased` flag
- show deceased status in lists and payer cards
- block contract and payment creation for deceased payers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df1fae9e08321a33c9f4c323cd37d