### PR TITLE
feat: add heirs support and deceased flag UI

### DIFF
--- a/crm/payer_request.py
+++ b/crm/payer_request.py
@@ -80,7 +80,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     keyboard = [
         [
             InlineKeyboardButton(
-                f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}",
+                f"{p['id']}: {'🕯 ' if p['is_deceased'] else ''}{p['name']}",
                 callback_data=f"payer:{p['id']}"
             )
         ]
@@ -121,7 +121,7 @@ async def search_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     keyboard = [
         [
             InlineKeyboardButton(
-                f"{ '⚰️ ' if r['is_deceased'] else ''}{r['name']} (ID:{r['id']})",
+                f"{ '🕯 ' if r['is_deceased'] else ''}{r['name']} (ID:{r['id']})",
                 callback_data=f"payer:{r['id']}"
             )
         ]

--- a/dialogs/contract.py
+++ b/dialogs/contract.py
@@ -393,12 +393,12 @@ async def set_valid_from(update: Update, context: ContextTypes.DEFAULT_TYPE):
         sqlalchemy.select(Payer).order_by(Payer.c.id.desc()).limit(3)
     )
     kb = ReplyKeyboardMarkup(
-        [[f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}"] for p in payers]
+        [[f"{p['id']}: {'🕯 ' if p['is_deceased'] else ''}{p['name']}"] for p in payers]
         + [["🔍 Пошук пайовика"], ["➕ Створити пайовика"], [BACK_BTN, CANCEL_BTN]],
         resize_keyboard=True,
     )
     context.user_data["recent_payers"] = {
-        f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
+        f"{p['id']}: {'🕯 ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
     }
     await update.message.reply_text("Оберіть пайовика:", reply_markup=kb)
     await update.message.reply_text("⬇️ Навігація", reply_markup=back_cancel_kb)

--- a/dialogs/edit_payer.py
+++ b/dialogs/edit_payer.py
@@ -44,7 +44,7 @@ async def edit_payer_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
     )
     status_btn = (
-        "↩️ Зняти статус 'Помер'" if row and row["is_deceased"] else "⚰️ Позначити як померлого"
+        "↩️ Зняти статус 'Помер'" if row and row["is_deceased"] else "🕯 Позначити як померлого"
     )
     keyboard = [
         [InlineKeyboardButton(status_btn, callback_data=f"toggle_deceased:{payer_id}")]

--- a/dialogs/land.py
+++ b/dialogs/land.py
@@ -171,11 +171,11 @@ async def set_owner_count(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Спочатку додайте хоча б одного пайовика!", reply_markup=lands_menu)
         return ConversationHandler.END
     kb = ReplyKeyboardMarkup(
-        [[f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}"] for p in payers] + [["🔍 Пошук за ПІБ"]],
+        [[f"{p['id']}: {'🕯 ' if p['is_deceased'] else ''}{p['name']}"] for p in payers] + [["🔍 Пошук за ПІБ"]],
         resize_keyboard=True,
     )
     context.user_data["payers"] = {
-        f"{p['id']}: {'⚰️ ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
+        f"{p['id']}: {'🕯 ' if p['is_deceased'] else ''}{p['name']}": p["id"] for p in payers
     }
     await update.message.reply_text(
         f"Оберіть власника 1 з {count}:", reply_markup=kb
@@ -190,6 +190,14 @@ async def select_owner(update: Update, context: ContextTypes.DEFAULT_TYPE):
     payer_id = context.user_data["payers"].get(text)
     if not payer_id:
         await update.message.reply_text("Оберіть пайовика зі списку (натисніть кнопку):")
+        return ASK_OWNER
+    row = await database.fetch_one(
+        sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+    )
+    if row and row["is_deceased"]:
+        await update.message.reply_text(
+            "❌ Пайовик позначений як померлий. Оберіть іншого."
+        )
         return ASK_OWNER
     context.user_data["owners"].append(payer_id)
     if len(context.user_data["owners"]) < context.user_data["owner_count"]:
@@ -208,11 +216,11 @@ async def search_owner(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Нічого не знайдено. Спробуйте ще:")
         return SEARCH_OWNER
     kb = ReplyKeyboardMarkup(
-        [[f"{r['id']}: {'⚰️ ' if r['is_deceased'] else ''}{r['name']}"] for r in rows] + [["◀️ Назад"]],
+        [[f"{r['id']}: {'🕯 ' if r['is_deceased'] else ''}{r['name']}"] for r in rows] + [["◀️ Назад"]],
         resize_keyboard=True,
     )
     context.user_data["search_results"] = {
-        f"{r['id']}: {'⚰️ ' if r['is_deceased'] else ''}{r['name']}": r["id"] for r in rows
+        f"{r['id']}: {'🕯 ' if r['is_deceased'] else ''}{r['name']}": r["id"] for r in rows
     }
     await update.message.reply_text("Оберіть пайовика:", reply_markup=kb)
     return CHOOSE_OWNER
@@ -232,6 +240,14 @@ async def choose_owner(update: Update, context: ContextTypes.DEFAULT_TYPE):
     payer_id = context.user_data.get("search_results", {}).get(text)
     if not payer_id:
         await update.message.reply_text("Оберіть зі списку або натисніть '◀️ Назад':")
+        return CHOOSE_OWNER
+    row = await database.fetch_one(
+        sqlalchemy.select(Payer.c.is_deceased).where(Payer.c.id == payer_id)
+    )
+    if row and row["is_deceased"]:
+        await update.message.reply_text(
+            "❌ Пайовик позначений як померлий. Оберіть іншого."
+        )
         return CHOOSE_OWNER
     context.user_data["owners"].append(payer_id)
     if len(context.user_data["owners"]) < context.user_data["owner_count"]:

--- a/dialogs/payment.py
+++ b/dialogs/payment.py
@@ -211,7 +211,7 @@ async def global_add_payment_search(update: Update, context: ContextTypes.DEFAUL
     keyboard = [
         [
             InlineKeyboardButton(
-                f"\U0001F464 {'⚰️ ' if r['is_deceased'] else ''}{r['name']}",
+                f"\U0001F464 {'🕯 ' if r['is_deceased'] else ''}{r['name']}",
                 callback_data=f"pay_select:{r['id']}"
             )
         ]

--- a/dialogs/search.py
+++ b/dialogs/search.py
@@ -68,7 +68,7 @@ async def payer_search_do(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("Пайовика не знайдено.")
         return ConversationHandler.END
     for p in results:
-        status = " ⚰️" if getattr(p, "is_deceased", False) else ""
+        status = " 🕯" if getattr(p, "is_deceased", False) else ""
         btn = InlineKeyboardButton("Картка", callback_data=f"payer_card:{p.id}")
         await update.message.reply_text(
             f"{p.id}. {p.name}{status} (ІПН: {p.ipn})",


### PR DESCRIPTION
## Summary
- add `heir` table and helpers to link deceased payers with heirs
- show candle icon for deceased payers and list heirs in payer card
- block land ownership selection for deceased payers

## Testing
- `python -m py_compile crm/payer_request.py db.py dialogs/contract.py dialogs/edit_payer.py dialogs/land.py dialogs/payer.py dialogs/payment.py dialogs/search.py`


------
https://chatgpt.com/codex/tasks/task_e_688dfb6bcbe083219badcc7fdac4aee7