### PR TITLE
Add advanced payment report with filters and Excel export

### DIFF
--- a/keyboards/reports.py
+++ b/keyboards/reports.py
@@ -1,0 +1,44 @@
+from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def status_filter_kb() -> InlineKeyboardMarkup:
+    """Keyboard for selecting payment status filter."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Очікує", callback_data="status:pending"),
+                InlineKeyboardButton("Виплачено", callback_data="status:paid"),
+            ],
+            [
+                InlineKeyboardButton("Частково", callback_data="status:partial"),
+                InlineKeyboardButton("Виплата спадкоємцю", callback_data="status:heir"),
+            ],
+            [InlineKeyboardButton("Пропустити", callback_data="status:any")],
+        ]
+    )
+
+
+def heirs_filter_kb() -> InlineKeyboardMarkup:
+    """Keyboard to choose whether to show only heir payments."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Лише спадкоємці", callback_data="heirs:yes"),
+                InlineKeyboardButton("Всі", callback_data="heirs:no"),
+            ]
+        ]
+    )
+
+
+def report_nav_kb(has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    """Pagination and export keyboard."""
+    rows: list[list[InlineKeyboardButton]] = []
+    nav_row: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav_row.append(InlineKeyboardButton("◀️ Назад", callback_data="payrep_prev"))
+    if has_next:
+        nav_row.append(InlineKeyboardButton("Вперед ▶️", callback_data="payrep_next"))
+    if nav_row:
+        rows.append(nav_row)
+    rows.append([InlineKeyboardButton("📤 Експорт", callback_data="payrep_export")])
+    return InlineKeyboardMarkup(rows)

--- a/main.py
+++ b/main.py
@@ -60,9 +60,7 @@ from dialogs.payment import (
     select_contract_cb,
     show_payments,
     list_inheritance_debts,
-    payment_reports_start,
-    payment_report_cb,
-    payment_report_csv_cb,
+    payment_report_conv,
 )
 from dialogs.edit_field import edit_field_conv
 from dialogs.edit_land import edit_land_conv
@@ -154,8 +152,7 @@ application.add_handler(edit_payer_conv)
 application.add_handler(global_add_payment_conv)
 application.add_handler(MessageHandler(filters.Regex("^📋 Перелік виплат$"), show_payments))
 application.add_handler(MessageHandler(filters.Regex("^🔍 Борг перед спадкоємцем$"), list_inheritance_debts))
-application.add_handler(MessageHandler(filters.Regex("^💳 Звіти по виплатах$"), payment_reports_start))
-application.add_handler(MessageHandler(filters.Regex("^💸 Звіт по виплатах$"), payment_reports_start))
+application.add_handler(payment_report_conv)
 
 # --- Потенційні пайовики ---
 application.add_handler(add_potential_conv)
@@ -213,8 +210,6 @@ application.add_handler(change_status_conv)
 application.add_handler(add_payment_conv)
 application.add_handler(CallbackQueryHandler(select_payer_cb, pattern=r"^pay_select:\d+$"))
 application.add_handler(CallbackQueryHandler(select_contract_cb, pattern=r"^pay_contract:\d+$"))
-application.add_handler(CallbackQueryHandler(payment_report_cb, pattern=r"^pay_report:\d+$"))
-application.add_handler(CallbackQueryHandler(payment_report_csv_cb, pattern=r"^pay_csv:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_summary_cb, pattern=r"^payment_summary:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_history_cb, pattern=r"^payment_history:\d+$"))
 application.add_handler(CallbackQueryHandler(generate_contract_pdf_cb, pattern=r"^generate_contract_pdf:\d+$"))

--- a/utils/reports.py
+++ b/utils/reports.py
@@ -1,0 +1,31 @@
+from io import BytesIO
+from typing import Iterable
+
+
+async def payments_to_excel(rows: Iterable[dict]) -> BytesIO:
+    """Generate Excel file from payment rows.
+
+    Each row must contain keys: payment_date, payer_name, company_name,
+    amount, status, is_heir.
+    """
+    # Import here to avoid hard dependency during module import
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Дата", "Пайовик", "Компанія", "Сума", "Статус", "Спадкоємець"])
+    for r in rows:
+        ws.append(
+            [
+                r["payment_date"].strftime("%d.%m.%Y"),
+                r["payer_name"],
+                r["company_name"],
+                float(r["amount"] or 0),
+                r["status"],
+                "так" if r["is_heir"] else "ні",
+            ]
+        )
+    bio = BytesIO()
+    wb.save(bio)
+    bio.seek(0)
+    return bio


### PR DESCRIPTION
## Summary
- add keyboards and utilities for payment report filtering, pagination, and Excel export
- implement database query and conversation handlers for flexible payment reports
- register the new admin-only payment report conversation

## Testing
- `pip install openpyxl`
- `python -m py_compile dialogs/payment.py keyboards/reports.py utils/reports.py db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f33e1b9ec8321a39c58b5ae415aac