### PR TITLE
Add field coverage report with Excel export

### DIFF
--- a/dialogs/fields_report.py
+++ b/dialogs/fields_report.py
@@ -1,0 +1,70 @@
+from telegram import Update, InputFile
+from telegram.ext import (
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    CallbackQueryHandler,
+    CommandHandler,
+    filters,
+)
+
+from handlers.menu import admin_only
+from dialogs.payer import to_menu
+from db import get_fields_report
+from keyboards.reports import report_nav_kb
+from utils.reports import fields_report_to_excel
+
+
+(FR_SHOW,) = range(1)
+
+
+@admin_only
+async def fields_report_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    msg = await update.message.reply_text("Формую звіт...")
+    rows = await get_fields_report()
+
+    lines: list[str] = ["📈 <b>Статистика по полях</b>"]
+    for r in rows:
+        lines.extend(
+            [
+                f"\n🌾 Поле: {r['name']}",
+                f"📐 Фізична площа: {float(r['physical_area'] or 0):.2f} га",
+                f"📍 Ділянки: {float(r['plots_area'] or 0):.2f} га",
+                f"📄 З договорами: {float(r['contract_area'] or 0):.2f} га",
+                f"🔁 Без договорів: {float(r['without_contract'] or 0):.2f} га",
+                f"✅ Покриття: {float(r['coverage'] or 0):.2f}%",
+            ]
+        )
+
+    await msg.edit_text(
+        "\n".join(lines),
+        reply_markup=report_nav_kb(False, False),
+        parse_mode="HTML",
+    )
+    return FR_SHOW
+
+
+@admin_only
+async def fields_report_export_cb(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    rows = await get_fields_report()
+    bio = await fields_report_to_excel(rows)
+    await query.message.reply_document(
+        document=InputFile(bio, filename="fields_report.xlsx")
+    )
+    await query.answer()
+    return FR_SHOW
+
+
+fields_report_conv = ConversationHandler(
+    entry_points=[
+        MessageHandler(
+            filters.Regex("^📈 Статистика по полях$"), fields_report_start
+        )
+    ],
+    states={
+        FR_SHOW: [CallbackQueryHandler(fields_report_export_cb, pattern=r"^payrep_export$")]
+    },
+    fallbacks=[CommandHandler("start", to_menu)],
+)
+

--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -103,11 +103,7 @@ reports_menu_admin = ReplyKeyboardMarkup(
 )
 
 reports_menu_user = ReplyKeyboardMarkup(
-    [
-        ["📈 Статистика по полях"],
-        ["◀️ Назад"],
-    ],
-    resize_keyboard=True,
+    [["◀️ Назад"]], resize_keyboard=True
 )
 
 # --- Меню пошуку ---

--- a/main.py
+++ b/main.py
@@ -65,6 +65,7 @@ from dialogs.payment import (
 from dialogs.rent_summary import rent_summary_conv
 from dialogs.land_report import land_report_conv
 from dialogs.land_overview import land_overview_conv
+from dialogs.fields_report import fields_report_conv
 from dialogs.contract_overview import contract_overview_conv
 from dialogs.edit_field import edit_field_conv
 from dialogs.edit_land import edit_land_conv
@@ -160,6 +161,7 @@ application.add_handler(payment_report_conv)
 application.add_handler(rent_summary_conv)
 application.add_handler(land_report_conv)
 application.add_handler(land_overview_conv)
+application.add_handler(fields_report_conv)
 application.add_handler(contract_overview_conv)
 
 # --- Потенційні пайовики ---

--- a/utils/reports.py
+++ b/utils/reports.py
@@ -220,6 +220,50 @@ async def land_overview_to_excel(
     return bio
 
 
+async def fields_report_to_excel(rows: Iterable[dict]) -> BytesIO:
+    """Generate Excel file for fields report."""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Поля"
+    ws.append(
+        [
+            "Назва поля",
+            "Фізична площа",
+            "Площа ділянок",
+            "Площа з договорами",
+            "Без договорів",
+            "% покриття",
+            "Кількість пайовиків",
+            "Сума оренди",
+        ]
+    )
+    for r in rows:
+        ws.append(
+            [
+                r.get("name") or "",
+                float(r.get("physical_area") or 0),
+                float(r.get("plots_area") or 0),
+                float(r.get("contract_area") or 0),
+                float(r.get("without_contract") or 0),
+                float(r.get("coverage") or 0),
+                int(r.get("payers") or 0),
+                float(r.get("rent_sum") or 0),
+            ]
+        )
+        row = ws.max_row
+        for col in range(2, 6):
+            ws.cell(row=row, column=col).number_format = "0.00"
+        ws.cell(row=row, column=6).number_format = "0.00"
+        ws.cell(row=row, column=8).number_format = "0.00"
+
+    bio = BytesIO()
+    wb.save(bio)
+    bio.seek(0)
+    return bio
+
+
 async def contracts_overview_to_excel(
     rows: Iterable[dict],
     companies: Iterable[dict],


### PR DESCRIPTION
## Summary
- add database query for per-field coverage and rent stats
- expose admin-only “field statistics” report with Telegram view and Excel export
- restrict field report menu to admins only

## Testing
- `python -m py_compile db.py dialogs/fields_report.py utils/reports.py main.py keyboards/menu.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f469b8fa08321aef67d5bf17a0349