### PR TITLE
feat: enhance sublease counterparty flow

### DIFF
--- a/crm/sublease.py
+++ b/crm/sublease.py
@@ -19,21 +19,27 @@ from telegram.ext import (
 
 from db import (
     add_counterparty,
-    get_counterparties,
     get_counterparty,
+    search_counterparties,
+    update_counterparty,
     add_sublease,
 )
+from crm.counterparty import _is_admin
 
 # conversation states
 (
     CHOOSE_TYPE,
-    COUNTERPARTY_LIST,
+    COUNTERPARTY_SEARCH,
+    COUNTERPARTY_RESULTS,
+    COUNTERPARTY_VIEW,
     COUNTERPARTY_CREATE_NAME,
     COUNTERPARTY_CREATE_EDRPOU,
     COUNTERPARTY_CREATE_PHONE,
+    COUNTERPARTY_EDIT_FIELD,
+    COUNTERPARTY_EDIT_VALUE,
     LAND_PLOTS,
     CONFIRM,
-) = range(7)
+) = range(11)
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -53,23 +59,38 @@ async def type_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
     context.user_data["sublease_type"] = query.data
-    rows = await get_counterparties()
+    await query.message.edit_text("Введіть назву або ЄДРПОУ контрагента:")
+    return COUNTERPARTY_SEARCH
+
+
+async def counterparty_search(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    context.user_data["cp_search"] = text
+    rows = await search_counterparties(text)
+    if not rows:
+        kb = []
+        if await _is_admin(update.effective_user.id):
+            kb.append([InlineKeyboardButton("➕ Створити", callback_data="cp:add")])
+        await update.message.reply_text(
+            "Не знайдено. Введіть інший запит:",
+            reply_markup=InlineKeyboardMarkup(kb) if kb else None,
+        )
+        return COUNTERPARTY_RESULTS
     keyboard = [
-        [
-            InlineKeyboardButton(
-                f"{r['name']} ({r['edrpou']})", callback_data=f"cp:{r['id']}"
-            )
-        ]
-        for r in rows[:5]
+        [InlineKeyboardButton(f"{r['name']} ({r['edrpou']})", callback_data=f"cp:{r['id']}")]
+        for r in rows
     ]
-    keyboard.append([InlineKeyboardButton("➕ Створити", callback_data="cp:add")])
-    await query.message.edit_text(
+    if await _is_admin(update.effective_user.id):
+        keyboard.append([InlineKeyboardButton("➕ Створити", callback_data="cp:add")])
+    await update.message.reply_text(
         "Оберіть контрагента:", reply_markup=InlineKeyboardMarkup(keyboard)
     )
-    return COUNTERPARTY_LIST
+    return COUNTERPARTY_RESULTS
 
 
-async def counterparty_list_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def counterparty_results_cb(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     query = update.callback_query
     await query.answer()
     data = query.data
@@ -81,11 +102,98 @@ async def counterparty_list_cb(update: Update, context: ContextTypes.DEFAULT_TYP
     if data.startswith("cp:"):
         cid = int(data.split(":")[1])
         context.user_data["counterparty_id"] = cid
-        await query.message.reply_text(
+        return await show_counterparty(query.message, context, cid)
+    return COUNTERPARTY_RESULTS
+
+
+async def show_counterparty(msg, context: ContextTypes.DEFAULT_TYPE, cid: int) -> int:
+    row = await get_counterparty(cid)
+    if not row:
+        if msg.from_user and msg.from_user.id == context.bot.id:
+            await msg.edit_text("Не знайдено.")
+        else:
+            await msg.reply_text("Не знайдено.")
+        return COUNTERPARTY_RESULTS
+    text = (
+        f"<b>{row['name']}</b>\n"
+        f"ЄДРПОУ: {row['edrpou']}\n"
+        f"Директор: {row.get('director','')}\n"
+        f"Адреса: {row.get('legal_address','')}\n"
+        f"Телефон: {row.get('phone','')}\n"
+        f"Email: {row.get('email','')}\n"
+        f"Примітка: {row.get('note','')}"
+    )
+    kb = [[InlineKeyboardButton("✅ Обрати", callback_data="select")]]
+    if await _is_admin(msg.chat_id if msg.chat_id else msg.from_user.id):
+        kb.append([InlineKeyboardButton("✏️ Редагувати", callback_data="edit")])
+    kb.append([InlineKeyboardButton("◀️ Назад", callback_data="back")])
+    if msg.from_user and msg.from_user.id == context.bot.id:
+        await msg.edit_text(text, reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
+    else:
+        await msg.reply_text(text, reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
+    return COUNTERPARTY_VIEW
+
+
+async def counterparty_view_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    data = query.data
+    if data == "select":
+        await query.message.edit_text(
             "Введіть ID ділянок через кому:", reply_markup=ReplyKeyboardRemove()
         )
         return LAND_PLOTS
-    return COUNTERPARTY_LIST
+    if data == "edit":
+        kb = [
+            [InlineKeyboardButton("Назва", callback_data="field:name")],
+            [InlineKeyboardButton("ЄДРПОУ", callback_data="field:edrpou")],
+            [InlineKeyboardButton("Телефон", callback_data="field:phone")],
+            [InlineKeyboardButton("◀️ Назад", callback_data="back")],
+        ]
+        await query.message.edit_text(
+            "Оберіть поле для редагування:", reply_markup=InlineKeyboardMarkup(kb)
+        )
+        return COUNTERPARTY_EDIT_FIELD
+    if data == "back":
+        search = context.user_data.get("cp_search", "")
+        rows = await search_counterparties(search)
+        keyboard = [
+            [InlineKeyboardButton(f"{r['name']} ({r['edrpou']})", callback_data=f"cp:{r['id']}")]
+            for r in rows
+        ]
+        if await _is_admin(query.from_user.id):
+            keyboard.append([InlineKeyboardButton("➕ Створити", callback_data="cp:add")])
+        await query.message.edit_text(
+            "Оберіть контрагента:", reply_markup=InlineKeyboardMarkup(keyboard)
+        )
+        return COUNTERPARTY_RESULTS
+    return COUNTERPARTY_VIEW
+
+
+async def edit_field_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    data = query.data
+    if data == "back":
+        cid = context.user_data.get("counterparty_id")
+        return await show_counterparty(query.message, context, cid)
+    if data.startswith("field:"):
+        field = data.split(":")[1]
+        context.user_data["edit_field"] = field
+        await query.message.reply_text(
+            "Введіть нове значення:", reply_markup=ReplyKeyboardRemove()
+        )
+        return COUNTERPARTY_EDIT_VALUE
+    return COUNTERPARTY_EDIT_FIELD
+
+
+async def edit_value_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    field = context.user_data.get("edit_field")
+    cid = context.user_data.get("counterparty_id")
+    value = update.message.text.strip()
+    await update_counterparty(cid, {field: value})
+    await update.message.reply_text("Збережено.")
+    return await show_counterparty(update.message, context, cid)
 
 
 async def create_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -110,7 +218,9 @@ async def create_phone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         }
     )
     context.user_data["counterparty_id"] = cid
-    await update.message.reply_text("Контрагента створено. Введіть ID ділянок через кому:")
+    await update.message.reply_text(
+        "Контрагента створено. Введіть ID ділянок через кому:"
+    )
     return LAND_PLOTS
 
 
@@ -167,10 +277,17 @@ sublease_conv = ConversationHandler(
     entry_points=[MessageHandler(filters.Regex("^➕ Суборенда$"), start)],
     states={
         CHOOSE_TYPE: [CallbackQueryHandler(type_cb)],
-        COUNTERPARTY_LIST: [CallbackQueryHandler(counterparty_list_cb)],
+        COUNTERPARTY_SEARCH: [MessageHandler(filters.TEXT & ~filters.COMMAND, counterparty_search)],
+        COUNTERPARTY_RESULTS: [
+            CallbackQueryHandler(counterparty_results_cb),
+            MessageHandler(filters.TEXT & ~filters.COMMAND, counterparty_search),
+        ],
+        COUNTERPARTY_VIEW: [CallbackQueryHandler(counterparty_view_cb)],
         COUNTERPARTY_CREATE_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, create_name)],
         COUNTERPARTY_CREATE_EDRPOU: [MessageHandler(filters.TEXT & ~filters.COMMAND, create_edrpou)],
         COUNTERPARTY_CREATE_PHONE: [MessageHandler(filters.TEXT & ~filters.COMMAND, create_phone)],
+        COUNTERPARTY_EDIT_FIELD: [CallbackQueryHandler(edit_field_cb)],
+        COUNTERPARTY_EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_value_cb)],
         LAND_PLOTS: [MessageHandler(filters.TEXT & ~filters.COMMAND, land_plots)],
         CONFIRM: [CallbackQueryHandler(confirm_cb)],
     },


### PR DESCRIPTION
## Summary
- implement search-driven counterparty selection for sublease FSM
- allow detailed view and inline editing of counterparties
- ensure newly created counterparties link back to sublease flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5a732de883218b79f6bd08c96d60