### PR TITLE
Fix quoting for agreement_template migration

### DIFF
--- a/db.py
+++ b/db.py
@@ -1533,7 +1533,7 @@ with engine.begin() as conn:
         'ALTER TABLE "contract" ADD COLUMN IF NOT EXISTS template_id INTEGER REFERENCES agreement_template(id)'
     ))
     conn.execute(sqlalchemy.text(
-        'ALTER TABLE "agreement_template" ADD COLUMN IF NOT EXISTS template_type VARCHAR(32) DEFAULT \''single\''' 
+        "ALTER TABLE \"agreement_template\" ADD COLUMN IF NOT EXISTS template_type VARCHAR(32) DEFAULT 'single'"
     ))
     conn.execute(sqlalchemy.text(
         'ALTER TABLE "crm_events" ADD COLUMN IF NOT EXISTS event_datetime TIMESTAMP'


### PR DESCRIPTION
## Summary
- fix syntax error from improperly escaped default value in agreement_template migration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f706d884c8321afb5e1bcf26f2395