### PR TITLE
Fix contract generation template handling

### DIFF
--- a/contract_generation_v2.py
+++ b/contract_generation_v2.py
@@ -371,7 +371,7 @@ async def generate_contract_v2(contract_id: int) -> tuple[str, str]:
             + ("одним" if tmpl_scope == "single" else "кількома")
             + " пайовиками. Завантажте відповідний шаблон."
         )
-    template = templates[0]
+    template = dict(templates[0])
 
     tmp_doc = f"temp_docs/template_{contract_id}.docx"
     os.makedirs("temp_docs", exist_ok=True)


### PR DESCRIPTION
## Summary
- Convert template database record to a standard dict so `get` calls work during contract generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aef4836308321bd68de5c8c169619