### PR TITLE
Remove PDF contract generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ The bot will substitute the list of payers into the `payers` variable.
 ## Contract generation
 
 Use `contract_generation_v2.generate_contract_v2(contract_id)` to build a
-contract PDF for a specific record. The function loads the contract, payer,
+contract DOCX for a specific record. The function loads the contract, payer,
 company and land plot information from the database, fills the first active
-agreement template and converts it to PDF. The PDF is uploaded to the configured
+agreement template and produces a DOCX file uploaded to the configured
 FTP server.
 
 **Parameters**
@@ -95,13 +95,8 @@ FTP server.
 - `contract_id` – identifier of the contract to generate.
 
 The call returns `(remote_path, log)` where `remote_path` is the FTP path of the
-uploaded PDF and `log` describes which template placeholders were filled or left
+uploaded DOCX and `log` describes which template placeholders were filled or left
 empty.
-
-LibreOffice (``soffice``) should be installed on the system for DOCX→PDF
-conversion. The helper runs ``libreoffice`` in headless mode and falls back to
-``unoconv`` if LibreOffice is unavailable. On Windows or macOS, the optional
-``docx2pdf`` package can be used if Microsoft Word is installed.
 
 ## Навігація
 

--- a/main.py
+++ b/main.py
@@ -62,13 +62,12 @@ from dialogs.contract import (
     show_contracts,
     agreement_card,
     to_contracts,
-    send_contract_pdf,
     contract_docs,
     delete_contract_prompt,
     delete_contract,
     agreement_delete_prompt,
     agreement_delete_confirm,
-    generate_contract_pdf_cb,
+    generate_contract_docx_cb,
     edit_contract_conv,
     change_status_conv,
     payment_summary_cb,
@@ -224,7 +223,7 @@ application.add_handler(edit_land_conv)
 application.add_handler(edit_land_owner_conv)
 application.add_handler(edit_company_conv)
 
-# --- PDF через FTP ---
+# --- Документи через FTP ---
 application.add_handler(add_docs_conv)
 application.add_handler(CallbackQueryHandler(send_pdf, pattern=r"^send_pdf:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_pdf, pattern=r"^delete_pdf_db:\d+$"))
@@ -245,14 +244,13 @@ application.add_handler(CallbackQueryHandler(select_payer_cb, pattern=r"^pay_sel
 application.add_handler(CallbackQueryHandler(select_contract_cb, pattern=r"^pay_contract:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_summary_cb, pattern=r"^payment_summary:\d+$"))
 application.add_handler(CallbackQueryHandler(payment_history_cb, pattern=r"^payment_history:\d+$"))
-application.add_handler(CallbackQueryHandler(generate_contract_pdf_cb, pattern=r"^generate_contract_pdf:\d+$"))
+application.add_handler(CallbackQueryHandler(generate_contract_docx_cb, pattern=r"^generate_contract_docx:\d+$"))
 application.add_handler(CallbackQueryHandler(contract_docs, pattern=r"^contract_docs:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_contract_prompt, pattern=r"^delete_contract:\d+$"))
 application.add_handler(CallbackQueryHandler(delete_contract, pattern=r"^confirm_delete_contract:\d+$"))
 application.add_handler(CallbackQueryHandler(agreement_delete_prompt, pattern=r"^agreement_delete:\d+$"))
 application.add_handler(CallbackQueryHandler(agreement_delete_confirm, pattern=r"^agreement_delete_confirm$"))
 application.add_handler(CallbackQueryHandler(to_contracts, pattern=r"^to_contracts$"))
-application.add_handler(CallbackQueryHandler(send_contract_pdf, pattern=r"^view_pdf:contract:\d+:.+"))
 for cb in potential_callbacks:
     application.add_handler(cb)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,5 +48,4 @@ PyPDF2
 psycopg2-binary>=2.9
 
 docxtpl
-docx2pdf>=0.1.8
 openpyxl


### PR DESCRIPTION
## Summary
- drop PDF conversion and output only DOCX contracts
- update bot callbacks and docs for DOCX contract generation
- remove optional PDF conversion dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af7cfbe008321980cc6279db51f42